### PR TITLE
feat(security): enable Firebase App Check client-side

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+      - development
+  pull_request:
+    branches:
+      - main
+      - development
+
+jobs:
+  validate:
+    name: Lint, Type Check & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Lint
+        run: pnpm run lint
+
+      - name: Run Type Check
+        run: npx tsc --noEmit
+
+      - name: Run Build
+        run: pnpm run build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,9 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: [".next/**", "node_modules/**", "dist/**", "out/**", "graphify-out/**"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     rules: {

--- a/lib/context/AppProviders.tsx
+++ b/lib/context/AppProviders.tsx
@@ -2,12 +2,17 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { ReactNode, useState } from "react";
+import { ReactNode, useState, useEffect } from "react";
 import { ThemeProvider } from "./ThemeProvider";
 import { AuthProvider } from "./AuthProvider";
+import { initAppCheck } from "@/lib/services/firebase/appCheck";
 
 export default function AppProvider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
+
+  useEffect(() => {
+    initAppCheck();
+  }, []);
 
   return (
     <ThemeProvider

--- a/lib/services/firebase/ai.ts
+++ b/lib/services/firebase/ai.ts
@@ -1,12 +1,8 @@
 import { getAI, getGenerativeModel, GoogleAIBackend } from "firebase/ai";
 import { app } from "./base";
 import { AI_SYSTEM_PROMPT } from "../../constants";
-import { initAppCheck } from "./appCheck";
-import { zodToGeminiSchema } from "./schema-utils";
 
 import { toolDeclarations } from "./tools";
-
-initAppCheck();
 
 const ai = getAI(app, { backend: new GoogleAIBackend() });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -p 3030",
     "build": "next build",
     "start": "next start -p 3030",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
Initializes Firebase App Check on mount at the root provider layout level, protecting all Firebase database/auth/storage calls across the entire frontend application.

Closes #22

### Core Changes:
- Wrapped `initAppCheck()` inside a client-side `useEffect` hook in `AppProviders.tsx`.
- Removed redundant module-level `initAppCheck()` import and invocation in `ai.ts` to avoid double-initialization.