### PR TITLE
feat(firebase): enable Firestore offline persistence

### DIFF
--- a/lib/services/firebase/db.ts
+++ b/lib/services/firebase/db.ts
@@ -1,4 +1,9 @@
-import { getFirestore } from "firebase/firestore";
+import { initializeFirestore, persistentLocalCache, persistentMultipleTabManager } from "firebase/firestore";
 import { app } from "./base";
 
-export const db = getFirestore(app);
+export const db = initializeFirestore(app, {
+  localCache: persistentLocalCache({
+    tabManager: persistentMultipleTabManager(),
+  }),
+});
+


### PR DESCRIPTION
Enables Firestore's multi-tab persistent local cache to allow users to read and write data seamlessly when offline or in low-connectivity areas.

Closes #29

### Core Changes:
- Refactored Firestore database initialization in `db.ts` to use `initializeFirestore()` with `persistentLocalCache` and `persistentMultipleTabManager`.
- Enables synchronized multi-tab IndexedDB cache storage that automatically syncs local offline changes to the Cloud Firestore backend when connectivity is restored.