### PR TITLE
feat(pagination): cursor-based pagination and infinite scroll UI

### DIFF
--- a/components/journals/JournalsList.tsx
+++ b/components/journals/JournalsList.tsx
@@ -1,10 +1,12 @@
-import { useJournals } from "@/lib/hooks/useJournals";
+import { useInfiniteJournals } from "@/lib/hooks/useJournals";
 import { useNProgressRouter } from "../layout/link/CustomLink";
 import { GridCardWithOverlay } from "@/components/ui/GridCardWithOverlay";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import Empty from "../Empty";
 import { BookOpenText } from "lucide-react";
+import { useInView } from "react-intersection-observer";
+import { useEffect } from "react";
 
 const JournalsList = ({
   chapterId,
@@ -13,8 +15,23 @@ const JournalsList = ({
   chapterId: string;
   className?: string;
 }) => {
-  const { data: journals, isLoading } = useJournals(chapterId);
+  const { 
+    data, 
+    fetchNextPage, 
+    hasNextPage, 
+    isFetchingNextPage, 
+    isLoading 
+  } = useInfiniteJournals(chapterId, 10);
   const { routerPush } = useNProgressRouter();
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, fetchNextPage]);
+
+  const journals = data?.pages.flatMap((page) => page.journals) || [];
 
   return (
     <div className={cn("space-y-4", className)}>
@@ -25,7 +42,7 @@ const JournalsList = ({
             <Skeleton key={i} className="h-32 w-full" />
           ))}
         </div>
-      ) : !journals?.length ? (
+      ) : !journals.length ? (
         <Empty
           icon={<BookOpenText className="emptyIcon" />}
           title="No journals yet"
@@ -36,21 +53,34 @@ const JournalsList = ({
           }}
         />
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {journals?.map(({ id, title, coverImage, location, date }) => (
-            <GridCardWithOverlay
-              className="cursor-pointer hover:shadow-lg transition"
-              onClick={() =>
-                routerPush(`/chapters/${chapterId}/journals/${id}`)
-              }
-              key={id}
-              title={title}
-              date={date}
-              image={coverImage}
-              location={location}
-            />
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {journals.map(({ id, title, coverImage, location, date }) => (
+              <GridCardWithOverlay
+                className="cursor-pointer hover:shadow-lg transition"
+                onClick={() =>
+                  routerPush(`/chapters/${chapterId}/journals/${id}`)
+                }
+                key={id}
+                title={title}
+                date={date}
+                image={coverImage}
+                location={location}
+              />
+            ))}
+          </div>
+
+          {/* Infinite Scroll loading marker */}
+          {hasNextPage && (
+            <div ref={ref} className="flex justify-center py-6">
+              {isFetchingNextPage ? (
+                <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              ) : (
+                <span className="text-xs text-muted-foreground">Load more</span>
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/planner/tasks/TasksList.tsx
+++ b/components/planner/tasks/TasksList.tsx
@@ -1,4 +1,4 @@
-import { useTasks } from "@/lib/hooks/useTasks";
+import { useInfiniteTasks } from "@/lib/hooks/useTasks";
 import { ListChecks } from "lucide-react";
 import usePlanner from "@/lib/hooks/usePlanner";
 import Empty from "../../Empty";
@@ -7,6 +7,8 @@ import TaskForm from "./TaskForm";
 import { TaskCard } from "./TaskCard";
 import ResponsiveDialogDrawer from "../../ui/ResponsiveDialogDrawer";
 import { getPluralWord } from "@/lib/utils";
+import { useInView } from "react-intersection-observer";
+import { useEffect } from "react";
 
 function SectionHeader({ label, count }: { label: string; count: number }) {
   return (
@@ -22,8 +24,21 @@ function SectionHeader({ label, count }: { label: string; count: number }) {
 }
 
 const TasksList = () => {
-  const { data: tasks, isLoading } = useTasks();
+  const { 
+    data, 
+    fetchNextPage, 
+    hasNextPage, 
+    isFetchingNextPage, 
+    isLoading 
+  } = useInfiniteTasks(undefined, 15);
   const { selectedTaskId, setSelectedTaskId } = usePlanner();
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, fetchNextPage]);
 
   const isDialogOpen = (dialogId: string) => selectedTaskId === dialogId;
   const toggleDialog = (dialogId: string | null) => {
@@ -34,7 +49,9 @@ const TasksList = () => {
     setSelectedTaskId(null);
   };
 
-  const [completedTasks, pendingTasks] = tasks?.reduce(
+  const tasks = data?.pages.flatMap((page) => page.tasks) || [];
+
+  const [completedTasks, pendingTasks] = tasks.reduce(
     ([completed, pending], task) =>
       task.status === "completed"
         ? [[...completed, task], pending]
@@ -127,6 +144,17 @@ const TasksList = () => {
             )}
           </div>
         </>
+      )}
+
+      {/* Infinite Scroll loading marker */}
+      {hasNextPage && (
+        <div ref={ref} className="flex justify-center py-6">
+          {isFetchingNextPage ? (
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          ) : (
+            <span className="text-xs text-muted-foreground">Load more</span>
+          )}
+        </div>
       )}
 
       {/* Add Task Dialog */}

--- a/lib/hooks/useJournals.ts
+++ b/lib/hooks/useJournals.ts
@@ -1,6 +1,7 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
 import {
   getJournals,
+  getJournalsPaginated,
   getJournalById,
   addJournal,
   updateJournal,
@@ -20,6 +21,25 @@ export const useJournals = (chapterId?: string) => {
   return useQuery({
     queryKey: [JOURNAL_QUERY_KEY, userId, chapterId],
     queryFn: () => (userId && chapterId ? getJournals(userId, chapterId) : []),
+    enabled: !!userId && !!chapterId,
+  });
+};
+
+export const useInfiniteJournals = (chapterId?: string, pageSize: number = 25) => {
+  const { user } = useAuth();
+  const userId = user?.uid;
+
+  return useInfiniteQuery({
+    queryKey: [JOURNAL_QUERY_KEY, userId, chapterId, "infinite", pageSize],
+    queryFn: ({ pageParam }) =>
+      userId && chapterId
+        ? getJournalsPaginated(userId, chapterId, {
+            limit: pageSize,
+            startAfterDoc: pageParam as any,
+          })
+        : Promise.resolve({ journals: [], lastDoc: null }),
+    initialPageParam: null as any,
+    getNextPageParam: (lastPage) => lastPage.lastDoc,
     enabled: !!userId && !!chapterId,
   });
 };

--- a/lib/hooks/useTasks.ts
+++ b/lib/hooks/useTasks.ts
@@ -1,6 +1,7 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
 import {
   getTasks,
+  getTasksPaginated,
   getTaskById,
   addTask,
   updateTask,
@@ -20,6 +21,26 @@ export const useTasks = (query?: TaskFilter) => {
   return useQuery({
     queryKey: [TASK_QUERY_KEY, userId, query],
     queryFn: () => (userId ? getTasks(userId, query) : Promise.resolve([])),
+    enabled: !!userId,
+  });
+};
+
+/** Fetch tasks with infinite scroll cursor-based pagination */
+export const useInfiniteTasks = (query?: TaskFilter, pageSize: number = 25) => {
+  const { user } = useAuth();
+  const userId = user?.uid;
+  return useInfiniteQuery({
+    queryKey: [TASK_QUERY_KEY, userId, "infinite", query, pageSize],
+    queryFn: ({ pageParam }) =>
+      userId
+        ? getTasksPaginated(userId, {
+            ...query,
+            limit: pageSize,
+            startAfterDoc: pageParam as any,
+          })
+        : Promise.resolve({ tasks: [], lastDoc: null }),
+    initialPageParam: null as any,
+    getNextPageParam: (lastPage) => lastPage.lastDoc,
     enabled: !!userId,
   });
 };

--- a/lib/services/journals.ts
+++ b/lib/services/journals.ts
@@ -10,6 +10,11 @@ import {
   getDoc,
   setDoc,
   runTransaction,
+  query,
+  limit,
+  orderBy,
+  startAfter,
+  DocumentSnapshot,
 } from "firebase/firestore";
 import { DEFAULT_CHAPTER_ID } from "../constants";
 
@@ -171,3 +176,41 @@ export async function checkAndCreateNewChapter(
 function generateIdByName(newChapterId: string): string {
   return newChapterId.trim().toLowerCase().replace(/ /g, "-");
 }
+
+export interface PaginatedJournals {
+  journals: Journal[];
+  lastDoc: DocumentSnapshot | null;
+}
+
+export const getJournalsPaginated = async (
+  userId: string,
+  chapterId: string,
+  options?: { limit?: number; startAfterDoc?: DocumentSnapshot | null }
+): Promise<PaginatedJournals> => {
+  const journalsRef = collection(
+    db,
+    `users/${userId}/chapters/${chapterId}/journals`
+  );
+  
+  const constraints = [];
+  constraints.push(orderBy("createdAt", "desc"));
+  
+  if (options?.limit) {
+    constraints.push(limit(options.limit));
+  }
+  
+  if (options?.startAfterDoc) {
+    constraints.push(startAfter(options.startAfterDoc));
+  }
+  
+  const q = query(journalsRef, ...constraints);
+  const snapshot = await getDocs(q);
+  
+  return {
+    journals: snapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    })) as Journal[],
+    lastDoc: snapshot.docs[snapshot.docs.length - 1] || null,
+  };
+};

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -12,6 +12,8 @@ import {
   limit,
   where,
   orderBy,
+  startAfter,
+  DocumentSnapshot,
 } from "firebase/firestore";
 
 const getTasks = async (
@@ -94,4 +96,50 @@ const deleteTask = async (userId: string, taskId: string): Promise<void> => {
   await deleteDoc(taskRef);
 };
 
-export { getTasks, getTaskById, addTask, updateTask, deleteTask };
+export interface PaginatedTasks {
+  tasks: Task[];
+  lastDoc: DocumentSnapshot | null;
+}
+
+const getTasksPaginated = async (
+  userId: string,
+  filter?: TaskFilter & { startAfterDoc?: DocumentSnapshot | null }
+): Promise<PaginatedTasks> => {
+  const tasksRef = collection(db, `users/${userId}/tasks`);
+  const constraints = [];
+
+  constraints.push(orderBy("highPriority", "desc"));
+
+  if (filter?.status) {
+    constraints.push(where("status", "==", filter.status));
+  }
+
+  if (filter?.limit) {
+    constraints.push(limit(filter.limit));
+  }
+
+  if (filter?.startAfterDoc) {
+    constraints.push(startAfter(filter.startAfterDoc));
+  }
+
+  const q = query(tasksRef, ...constraints);
+
+  try {
+    const snapshot = await getDocs(q);
+    return {
+      tasks: snapshot.docs.map(
+        (doc) =>
+          ({
+            id: doc.id,
+            ...doc.data(),
+          } as Task)
+      ),
+      lastDoc: snapshot.docs[snapshot.docs.length - 1] || null,
+    };
+  } catch (error) {
+    console.error("Error fetching paginated tasks:", error);
+    throw error;
+  }
+};
+
+export { getTasks, getTasksPaginated, getTaskById, addTask, updateTask, deleteTask };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-day-picker": "8.10.1",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.55.0",
+    "react-intersection-observer": "^10.1.0",
     "react-markdown": "^10.1.0",
     "react-responsive": "^10.0.1",
     "react-swipeable": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       react-hook-form:
         specifier: ^7.55.0
         version: 7.56.4(react@19.1.0)
+      react-intersection-observer:
+        specifier: ^10.1.0
+        version: 10.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.1.4)(react@19.1.0)
@@ -4186,6 +4189,15 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-intersection-observer@10.1.0:
+    resolution: {integrity: sha512-V8HDu3+Llg6OEhOxx8LnUSS0t4VS+1Xk9ZatkI8Jct/H0CwKnqFTCu8NT3q7ghJTghTdIrEMPSWr2dkKPG+gdQ==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -9314,6 +9326,12 @@ snapshots:
   react-hook-form@7.56.4(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  react-intersection-observer@10.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
Implements cursor-based database pagination and infinite scroll UI for both tasks and journals to scale collections safely without high-memory or high-read costs on mount.

Closes #27

### Core Changes:
1. **Firestore Service Paginated APIs**:
   - Added `getTasksPaginated` in `tasks.ts` service using Firestore `limit` and `startAfter` queries.
   - Added `getJournalsPaginated` in `journals.ts` service using identical cursor-based configurations.
2. **React Query Infinite Scroll Hooks**:
   - Implements `useInfiniteTasks` and `useInfiniteJournals` query hooks in `useTasks.ts` and `useJournals.ts` utilizing `@tanstack/react-query`'s modern `useInfiniteQuery` pattern.
3. **Infinite Scroll UI Integration**:
   - Installed `react-intersection-observer` package.
   - Refactored `TasksList.tsx` and `JournalsList.tsx` components to use the new infinite query hooks, flattening multi-page payloads and appending next page fetches automatically when users scroll to the bottom of the list.
4. **Backwards Compatibility**:
   - Ensured absolute backwards compatibility with existing simple array fetching APIs.