### PR TITLE
feat(pwa): implement complete offline compatibility

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import { Metadata } from "next";
 import { Toaster } from "@/components/ui/sonner";
+import { OfflineIndicator } from "@/components/layout/OfflineIndicator";
 
 export const metadata: Metadata = {
   title: "App",
@@ -15,6 +16,7 @@ const Layout = ({
 }>) => {
   return (
     <ProtectedRoute>
+      <OfflineIndicator />
       {children}
       <NavigationBar />
       <Toaster />

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -7,10 +7,11 @@ export default function manifest(): MetadataRoute.Manifest {
     description:
       "A fast and intuitive personal journaling and planning app. Turn Moments Into Memories, Ideas Into Actions.",
     start_url: "/home",
+    scope: "/",
     display: "standalone",
     orientation: "portrait",
     theme_color: "#2e0f42",
-    background_color: "#ffffff",
+    background_color: "#0f0814",
     icons: [
       {
         purpose: "maskable",
@@ -23,6 +24,22 @@ export default function manifest(): MetadataRoute.Manifest {
         sizes: "512x512",
         src: "icon512_rounded.png",
         type: "image/png",
+      },
+    ],
+    shortcuts: [
+      {
+        name: "Home",
+        short_name: "Home",
+        description: "Go to Home",
+        url: "/home",
+        icons: [{ src: "icon512_rounded.png", sizes: "512x512" }],
+      },
+      {
+        name: "Planner",
+        short_name: "Planner",
+        description: "Go to Planner",
+        url: "/planner",
+        icons: [{ src: "icon512_rounded.png", sizes: "512x512" }],
       },
     ],
   };

--- a/app/offline/page.tsx
+++ b/app/offline/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { WifiOff, RefreshCw, Home, Calendar, BookOpen, Users, Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function OfflinePage() {
+  const quickLinks = [
+    { label: "Home", href: "/home", icon: Home },
+    { label: "Planner", href: "/planner", icon: Calendar },
+    { label: "Chapters", href: "/chapters", icon: BookOpen },
+    { label: "Characters", href: "/characters", icon: Users },
+    { label: "Settings", href: "/settings", icon: Settings },
+  ];
+
+  return (
+    <div className="min-h-screen w-full flex flex-col items-center justify-center p-4 bg-gradient-to-br from-purple-950 via-slate-900 to-indigo-950 text-foreground">
+      <div className="max-w-md w-full p-8 rounded-2xl backdrop-blur-xl bg-white/10 dark:bg-black/30 border border-white/15 shadow-2xl text-center space-y-6">
+        <div className="w-20 h-20 mx-auto rounded-full bg-purple-500/20 flex items-center justify-center border border-purple-500/30 text-purple-300 animate-pulse">
+          <WifiOff className="w-10 h-10" />
+        </div>
+
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight text-white">
+            You are currently offline
+          </h1>
+          <p className="text-sm text-purple-200/80">
+            ZapJot is currently unable to connect to the network. You can continue navigating cached routes or retry when connectivity is restored.
+          </p>
+        </div>
+
+        <Button
+          onClick={() => window.location.reload()}
+          className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 text-white font-medium shadow-lg transition-all flex items-center justify-center gap-2"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Retry Connection
+        </Button>
+
+        <div className="pt-4 border-t border-white/10">
+          <p className="text-xs font-semibold uppercase tracking-wider text-purple-300/80 mb-3">
+            Quick Navigation (Cached Routes)
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {quickLinks.map((link) => {
+              const Icon = link.icon;
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="flex items-center gap-2 p-2.5 rounded-lg bg-white/5 hover:bg-white/15 border border-white/10 hover:border-purple-400/40 text-xs text-purple-100 transition-all text-left"
+                >
+                  <Icon className="w-4 h-4 text-purple-300 shrink-0" />
+                  <span className="truncate">{link.label}</span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/OfflineIndicator.tsx
+++ b/components/layout/OfflineIndicator.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useNetworkStatus } from "@/lib/hooks/useNetworkStatus";
+import { toast } from "sonner";
+import { WifiOff } from "lucide-react";
+
+export function OfflineIndicator() {
+  const { isOnline } = useNetworkStatus();
+  const previousStatusRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    if (previousStatusRef.current === null) {
+      previousStatusRef.current = isOnline;
+      if (!isOnline) {
+        toast.warning("You are offline. Working with local cached data.");
+      }
+      return;
+    }
+
+    if (previousStatusRef.current !== isOnline) {
+      if (!isOnline) {
+        toast.warning("You are offline. Working with local cached data.");
+      } else {
+        toast.success("Back online! Syncing latest changes...");
+      }
+      previousStatusRef.current = isOnline;
+    }
+  }, [isOnline]);
+
+  if (isOnline) {
+    return null;
+  }
+
+  return (
+    <div className="fixed top-3 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-full bg-amber-500/90 text-amber-950 font-medium text-xs sm:text-sm shadow-lg backdrop-blur-md border border-amber-400/40 flex items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-300 pointer-events-auto">
+      <WifiOff className="w-4 h-4 shrink-0" />
+      <span>Offline Mode — Changes will be saved locally and synced automatically when back online</span>
+    </div>
+  );
+}

--- a/lib/context/AppProviders.tsx
+++ b/lib/context/AppProviders.tsx
@@ -8,7 +8,21 @@ import { AuthProvider } from "./AuthProvider";
 import { initAppCheck } from "@/lib/services/firebase/appCheck";
 
 export default function AppProvider({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            networkMode: "offlineFirst",
+            staleTime: 1000 * 60 * 5,
+            gcTime: 1000 * 60 * 60 * 24,
+          },
+          mutations: {
+            networkMode: "offlineFirst",
+          },
+        },
+      })
+  );
 
   useEffect(() => {
     initAppCheck();

--- a/lib/hooks/useNetworkStatus.ts
+++ b/lib/hooks/useNetworkStatus.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useNetworkStatus() {
+  const [isOnline, setIsOnline] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setIsOnline(navigator.onLine);
+    }
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return { isOnline };
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,58 @@ const withPWA = withPWAInit({
   dest: "public",
   disable: process.env.NODE_ENV === "development",
   register: true,
+  cacheOnFrontEndNav: true,
+  aggressiveFrontEndNavCaching: true,
+  reloadOnOnline: false,
+  fallbacks: {
+    document: "/offline",
+  },
+  workboxOptions: {
+    skipWaiting: true,
+    runtimeCaching: [
+      {
+        urlPattern: /^https:\/\/(?:fcm\.googleapis\.com|.*\.sentry\.io|.*\.google-analytics\.com|.*\.analytics\.google\.com)/i,
+        handler: "NetworkOnly",
+      },
+      {
+        urlPattern: ({ request }: { request: Request }) => request.mode === "navigate",
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "pages-cache",
+          networkTimeoutSeconds: 3,
+        },
+      },
+      {
+        urlPattern: /\/_next\/static\/.*/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "static-resources",
+        },
+      },
+      {
+        urlPattern: /^https:\/\/(fonts\.googleapis\.com|fonts\.gstatic\.com)/i,
+        handler: "CacheFirst",
+        options: {
+          cacheName: "google-fonts",
+          expiration: {
+            maxEntries: 30,
+            maxAgeSeconds: 365 * 24 * 60 * 60,
+          },
+        },
+      },
+      {
+        urlPattern: /^https:\/\/(?:res\.cloudinary\.com|lh3\.googleusercontent\.com).*|\.(?:png|jpg|jpeg|svg|webp|gif|ico)$/i,
+        handler: "CacheFirst",
+        options: {
+          cacheName: "images-cache",
+          expiration: {
+            maxEntries: 200,
+            maxAgeSeconds: 60 * 24 * 60 * 60,
+          },
+        },
+      },
+    ],
+  },
 });
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Summary
This PR implements complete offline compatibility for ZapJot PWA according to industry standards.

Closes #44, #45, #46, #47.

### Key Changes
1. **Service Worker Caching & Fallbacks (`next.config.ts`)**:
   - Configured `@ducanh2912/next-pwa` with Workbox runtime caching strategies:
     - Page navigation routes: `NetworkFirst` (3s timeout, fallback to `/offline`).
     - Static JS/CSS assets: `StaleWhileRevalidate`.
     - Fonts and Cloudinary images: `CacheFirst` with LRU expiration.
     - Excluded FCM, Sentry, and Analytics API calls via `NetworkOnly`.

2. **Web App Manifest Metadata (`app/manifest.ts`)**:
   - Added shortcuts, scope, theme colors (`#2e0f42`), background color (`#0f0814`), and standalone display mode for full PWA installability.

3. **Offline Fallback Page (`app/offline/page.tsx`)**:
   - Created standalone glassmorphic offline page matching ZapJot's design system with connection status, retry button, and quick links to cached routes (`/home`, `/planner`, `/chapters`, `/characters`, `/settings`).

4. **Network Monitoring & UI Banner (`lib/hooks/useNetworkStatus.ts`, `components/layout/OfflineIndicator.tsx`)**:
   - Added custom hook tracking `navigator.onLine` and `online`/`offline` window events.
   - Added `<OfflineIndicator />` floating top banner and Sonner toasts when toggling online/offline states. Mounted in `app/(main)/layout.tsx`.

5. **TanStack React Query Offline Mode (`lib/context/AppProviders.tsx`)**:
   - Configured `networkMode: "offlineFirst"` across queries and mutations so queries/mutations execute against Firestore's IndexedDB persistent local cache (`persistentLocalCache`) without erroring out while offline.

### Verification
- `npm run build` completed cleanly with exit code 0 (`✓ Compiled successfully in 15.6s`, static routes `/offline` and `/manifest.webmanifest` generated).
- `graphify update .` completed re-indexing knowledge graph for 246 files.