### PR TITLE
Merge `development` into `staging` (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-07-24
+
+### Added
+
+- **Gradient Theme Support:** Added gradient-based themes throughout the application with customizable gradient styling across UI components and navigation. (#59)
+- **Card Gradient Theming:** Introduced dedicated card gradient theme variables for consistent styling across cards and reusable UI components. (#59)
+- **Nested Settings Navigation:** Redesigned Settings with nested navigation, built-in back button support, and breadcrumb navigation for improved usability on desktop and mobile. (#59)
+- **Itinerary Import Flow:** Added a streamlined itinerary import experience with a custom confirmation dialog. (#59)
+
+### Changed
+
+- **Public Share Routes:** Migrated public sharing routes from `/share` to `/explore` for a more consistent public experience. (#59)
+- **Header Navigation:** Refactored and modularized the application header navigation for improved maintainability and future expansion. (#59)
+- **Public Share Schema:** Extended the public share schema to include itinerary budget information. (#59)
+
+### Fixed
+
+- **Explore Page Cleanup:** Removed unused imports and performed internal cleanup following the `/explore` migration. (#59)
+- **UI Polish & Maintenance:** Various internal refactors and styling improvements to support the new theming system and navigation architecture. (#59)
+- **Settings Back Button:** Added back button to settings page for mobile view. (#59)
+
 ## [1.5.0] - 2026-07-23
 
 ### Added
+
 - **Public Shared Items Hub (`/shared`):** Built a dual-tab dashboard page for logged-in users with **Public Hub** (browse & 1-click import community itineraries) and **My Public Shares** (manage, copy links, or unshare/delete public shares). (#55)
 - **Public Landing Page Navigation (`/explore`):** Added **Explore Community** link to top navigation bar on landing page for public web visitors. (#55)
 - **Social Media Card Aesthetic Grid (`PublicShareCard.tsx`):** Rendered public shares grid items as compact mini-social graphic cards using 5 preset themes (`midnight`, `sunset`, `emerald`, `rose`, `nordic`), glassmorphism badges, and author metadata. (#55)
@@ -17,11 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Printable Itinerary Export:** Built `PrintableItinerary.tsx` component with print button in `ItineraryDetailCard.tsx` for PDF/print generation. (#9)
 
 ### Fixed
+
 - **Cloudinary Overlay Focus Lock:** Solved Radix Dialog/Drawer focus lock when Cloudinary upload widget is active inside modals (`ResponsiveDialogDrawer.tsx` & `globals.css`). (#55)
 
 ## [1.4.1] - 2026-07-22
 
 ### Added
+
 - **Complete PWA Offline Compatibility:** Added comprehensive Workbox runtime caching (`StaleWhileRevalidate` page route caching, asset caching, Cloudinary image caching) and fallback routing via `@ducanh2912/next-pwa`. (#44)
 - **Offline Fallback Page:** Built a dedicated glassmorphic offline page at `app/offline/page.tsx` with connection status and quick navigation links to cached routes. (#45)
 - **Network Status & Floating Indicator:** Added `useNetworkStatus` hook and floating top `<OfflineIndicator />` banner + Sonner toasts for connectivity state transitions. (#46)
@@ -33,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.4.0] - 2026-07-21
 
 ### Added
+
 - **Google Calendar Real-Time Sync:** Integrated direct write-through synchronization between Firestore events (create, update, delete) and Google Calendar API. (#6)
 - **Firebase OAuth & Permissions Linking:** Added on-demand Google Calendar OAuth scope (`https://www.googleapis.com/auth/calendar`) requesting and account linking using `linkWithPopup` for Firebase email/password users. (#6)
 - **Recurrence & Reminder Sync:** Supported syncing daily, weekly, monthly, and yearly recurring events using standard iCalendar `RRULE` conversion, and dynamic notification reminder mapping with fallback to user config. (#6)
@@ -50,10 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Firestore Offline Caching**: Enabled persistent local caching (`persistentLocalCache` and `persistentMultipleTabManager`) in `db.ts` to allow full offline read/write support. (#29)
 
 ### Changed
+
 - **Service-Layer Schema Validation:** Integrated Zod schemas (`create*Schema` and `update*Schema`) inside all write endpoints of `tasks`, `events`, `goals`, `characters`, `chapters`, `journals`, and `itineraries` services to prevent database corruption. (#13)
 - **Atomic Journal Moves:** Refactored `moveJournal` to run the write/delete operations atomically within a Firestore Transaction. (#13)
 
 ### Fixed
+
 - **Unawaited Participant Synchronization:** Resolved race conditions during event creation/updates by wrapping concurrent updates in `Promise.all()`. (#13)
 - **Inconsistent Timestamps:** Unified all updated/created timestamp writes to follow ISO 8601 strings. (#13)
 - **Firestore documentId Queries:** Fixed event retrieval filters in `lib/services/events.ts` to query `documentId()` instead of matching against a string property `"id"`. (#13)
@@ -62,13 +89,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.1] - 2026-07-17
 
 ### Added
+
 - **Dynamic Calendar Empty State Filtering:** Hides empty day cards when displaying month-ranges or upcoming events list, returning a clean empty state panel instead.
 - **Save/Discard AI Reaction Context:** Appends system messages (`ChatRole.SYSTEM`) to the chatbot conversational history to ensure Gemini stays fully informed of user actions while keeping these operations hidden from the message bubbles UI.
 
 ### Changed
+
 - **Default Upcoming Events View:** Shifted the calendar default listing to display events from today onwards up to the end of the month, falling back to a full-month view only when the month is changed.
 
 ### Fixed
+
 - **Firestore Query Task Omission:** Pre-populated missing default task fields (`status`, `highPriority`, `subtasks`) during direct creation to prevent Firestore `orderBy("highPriority")` queries from omitting newly added items.
 - **Yearly Event Format Matching:** Corrected the date formatter helper inside calendar date ranges from `"M-D"` to `"MM-DD"` to align with the database schema and prevent yearly repeating events from hiding.
 - **Firebase Write Batch Safety:** Handled nullable fields directly (assigning `null` instead of leaving `undefined`) during batch updates to prevent Firestore SDK validation errors.
@@ -78,16 +108,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.0] - 2026-07-17
 
 ### Added
+
 - **AI Companion Personality (Zappy):** Implemented a warm, witty, and proactive AI companion system with relative temporal awareness and directives to check existence before creation, merge info semantically, and automatically cross-reference goals, events, itineraries, and tasks.
 - **Delete Capabilities for AI:** Equipped the AI agent with tools to permanently delete chapters (`delete_chapter`), journals (`delete_journal`), tasks (`delete_task`), events (`delete_event`), goals (`delete_goal`), characters (`delete_character`), and itineraries (`delete_itinerary`).
 - **Daily Briefing Tool:** Added `get_daily_briefing` tool which pulls today's schedule, pending tasks, active goals progress, and recent journals to offer comprehensive daily summaries when greeted.
 - **AI Settings Model Selection:** Bound the Settings AI panel dynamically to `AVAILABLE_MODELS` instead of static hardcoded lists.
 
 ### Changed
+
 - **Stable Chat Connection:** Refactored the core chat execution engine in `useAiChat.ts` to utilize the stable, non-streaming `chat.sendMessage` instead of `chat.sendMessageStream` to resolve `400 Bad Request` thought signature errors under the hood.
 - **UI Loading Indicators:** Switched typewriter text simulation to instant static responses with native pulsing loading indicators (`...`) during active backend operations, eliminating layout thrashing and markdown rendering flicker.
 
 ### Fixed
+
 - **Cache Race Conditions:** Patched `localStorage` history reload logic so that active in-memory cache queues are protected from being overwritten by stale values when routing or re-rendering.
 - **Vertex AI Schema Standardisation:** Capitalized all raw tool parameter schema types to `OBJECT` via `zodToGeminiSchema(z.object({}))` to satisfy strict Google/Vertex AI validator constraints and resolve 400 Bad Requests.
 - **Local Build Guard:** Protected `GOOGLE_SERVICE_ACCOUNT_JSON` JSON parsing in `check-notifications` endpoint to support local compilation without environment keys.

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,13 +1,8 @@
 import PageLayout from "@/components/layout/PageLayout";
 import SettingsPage from "@/components/settings/SettingsPage";
-import React from "react";
 
 const Settings = () => {
-  return (
-    <PageLayout headerProps={{ title: "Settings" }}>
-      <SettingsPage />
-    </PageLayout>
-  );
+  return <SettingsPage />;
 };
 
 export default Settings;

--- a/app/(main)/shared/page.tsx
+++ b/app/(main)/shared/page.tsx
@@ -113,7 +113,7 @@ export default function SharedPage() {
   };
 
   const handleCopyLink = async (shareId: string) => {
-    const url = `${window.location.origin}/share/${shareId}`;
+    const url = `${window.location.origin}/explore/${shareId}`;
     if (typeof navigator !== "undefined" && navigator.clipboard) {
       await navigator.clipboard.writeText(url);
       toast.success("Public link copied to clipboard!");

--- a/app/(main)/shared/page.tsx
+++ b/app/(main)/shared/page.tsx
@@ -7,33 +7,18 @@ import {
   deletePublicShare,
   PublicShare,
 } from "@/lib/services/publicShares";
-import { importPublicItinerary } from "@/lib/services/itineraries";
+import { duplicatePublicItineraryData } from "@/lib/services/itineraries";
 import { useAuth } from "@/lib/context/AuthProvider";
 import { toast } from "@/components/ui/sonner";
 import PageLayout from "@/components/layout/PageLayout";
 import { CustomLoader } from "@/components/layout/CustomLoader";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
-import {
-  Share2,
-  Globe,
-  UserCheck,
-  Search,
-  MapPin,
-  Calendar,
-  Sparkles,
-  Plus,
-  Trash2,
-  Copy,
-  BookOpen,
-  Link2,
-} from "lucide-react";
+import { Share2, Globe, UserCheck, Search } from "lucide-react";
 import { PublicShareCard } from "@/components/social-card/PublicShareCard";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
-import DeleteConfirm from "@/components/ui/delete-confirm";
+import ResponsiveDialogDrawer from "@/components/ui/ResponsiveDialogDrawer";
+import ItineraryForm from "@/components/planner/itineraries/ItineraryForm";
+import { Itinerary } from "@/types/itineraries";
 
 export default function SharedPage() {
   const router = useRouter();
@@ -50,6 +35,8 @@ export default function SharedPage() {
   const [myShares, setMyShares] = useState<PublicShare[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [importingId, setImportingId] = useState<string | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [itineraryData, setItineraryData] = useState<Itinerary>();
 
   const fetchItems = async () => {
     setIsLoading(true);
@@ -89,15 +76,20 @@ export default function SharedPage() {
 
     setImportingId(share.id);
     try {
-      await importPublicItinerary(user.uid, share);
-      toast.success("Itinerary imported into your planner!");
-      router.push("/planner");
+      const itinerary = duplicatePublicItineraryData(share);
+      setItineraryData(itinerary as Itinerary);
+      setIsDialogOpen(true);
     } catch (err) {
       console.error("Error importing itinerary:", err);
       toast.error("Failed to import itinerary");
     } finally {
       setImportingId(null);
     }
+  };
+
+  const handleSave = () => {
+    toast.success("Itinerary imported successfully!");
+    router.push("/planner");
   };
 
   const handleDeletePublicShare = async (shareId: string) => {
@@ -142,6 +134,11 @@ export default function SharedPage() {
       share.content?.toLowerCase().includes(query)
     );
   });
+
+  const handleClose = () => {
+    setIsDialogOpen(false);
+    setItineraryData(undefined);
+  };
 
   return (
     <PageLayout headerProps={{ title: "Shared Hub" }}>
@@ -261,6 +258,19 @@ export default function SharedPage() {
               />
             ))}
           </div>
+        )}
+        {isDialogOpen && (
+          <ResponsiveDialogDrawer
+            content={
+              <ItineraryForm
+                onClose={handleClose}
+                onSave={handleSave}
+                itineraryData={itineraryData}
+              />
+            }
+            title={itineraryData?.title || "Imported Itinerary"}
+            handleClose={handleClose}
+          />
         )}
       </div>
     </PageLayout>

--- a/app/(main)/shared/page.tsx
+++ b/app/(main)/shared/page.tsx
@@ -153,7 +153,7 @@ export default function SharedPage() {
             onClick={() => setSectionMode("mine")}
             className={`flex-1 sm:flex-none px-5 py-2 rounded-xl text-xs font-bold transition flex items-center justify-center gap-2 ${
               sectionMode === "mine"
-                ? "bg-primary text-primary-foreground shadow-md shadow-primary/20"
+                ? "bg-gradient-primary text-primary-foreground shadow-md shadow-primary/20"
                 : "text-muted-foreground hover:text-foreground"
             }`}
           >
@@ -165,7 +165,7 @@ export default function SharedPage() {
             onClick={() => setSectionMode("public")}
             className={`flex-1 sm:flex-none px-5 py-2 rounded-xl text-xs font-bold transition flex items-center justify-center gap-2 ${
               sectionMode === "public"
-                ? "bg-primary text-primary-foreground shadow-md shadow-primary/20"
+                ? "bg-gradient-primary text-primary-foreground shadow-md shadow-primary/20"
                 : "text-muted-foreground hover:text-foreground"
             }`}
           >
@@ -231,8 +231,8 @@ export default function SharedPage() {
           </div>
         ) : filteredShares.length === 0 ? (
           <div className="text-center py-16 bg-card rounded-2xl border border-border p-8 space-y-3">
-            <div className="w-12 h-12 rounded-full bg-purple-100 dark:bg-purple-950/60 flex items-center justify-center mx-auto text-purple-600">
-              <Share2 className="h-6 w-6" />
+            <div className="w-12 h-12 rounded-full bg-primary/10 dark:bg-purple-950/60 flex items-center justify-center mx-auto text-purple-600">
+              <Share2 className="h-6 w-6 text-primary" />
             </div>
             <h3 className="text-lg font-bold text-foreground">
               {sectionMode === "mine"

--- a/app/explore/[shareId]/page.tsx
+++ b/app/explore/[shareId]/page.tsx
@@ -8,7 +8,15 @@ import { useAuth } from "@/lib/context/AuthProvider";
 import { toast } from "@/components/ui/sonner";
 import { CustomLoader } from "@/components/layout/CustomLoader";
 import { WysiwygViewer } from "@/components/wysiwyg/viewer";
-import { Sparkles, Calendar, MapPin, CheckSquare, Clock, Plus, ArrowRight } from "lucide-react";
+import {
+  Sparkles,
+  Calendar,
+  MapPin,
+  CheckSquare,
+  Clock,
+  Plus,
+  ArrowRight,
+} from "lucide-react";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -108,7 +116,7 @@ export default function PublicSharePage() {
             <div className="flex items-center gap-2">
               <Badge
                 variant="outline"
-                className="text-xs font-semibold uppercase tracking-wider text-purple-300 border-purple-400/40 bg-purple-500/10 px-3 py-1"
+                className="text-xs font-semibold uppercase tracking-wider text-purple-500 border-purple-400/40 bg-purple-500/10 px-3 py-1"
               >
                 Shared {share.type === "itinerary" ? "Itinerary" : "Journal"}
               </Badge>

--- a/app/explore/[shareId]/page.tsx
+++ b/app/explore/[shareId]/page.tsx
@@ -251,6 +251,12 @@ export default function PublicSharePage() {
                 </CardContent>
               </Card>
             ))}
+            {/* Budget */}
+            {share.budget && share.budget > 0 && (
+              <span className="text-xs font-bold text-purple-600 dark:text-purple-400 bg-purple-100 dark:bg-purple-900/40 px-2.5 py-1 rounded-full">
+                Budget: ${share.budget}
+              </span>
+            )}
           </div>
         )}
       </div>

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,28 +1,14 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { getPublicShares, PublicShare } from "@/lib/services/publicShares";
 import { importPublicItinerary } from "@/lib/services/itineraries";
 import { useAuth } from "@/lib/context/AuthProvider";
 import { toast } from "@/components/ui/sonner";
-import PageLayout from "@/components/layout/PageLayout";
 import { CustomLoader } from "@/components/layout/CustomLoader";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
-import {
-  Compass,
-  Search,
-  MapPin,
-  Calendar,
-  Sparkles,
-  Plus,
-  ArrowRight,
-  BookOpen,
-} from "lucide-react";
-import Link from "next/link";
-import Image from "next/image";
+import { Compass, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { PublicShareCard } from "@/components/social-card/PublicShareCard";
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,8 +36,22 @@
   --radius: 0.6rem;
   --background: hsl(0 0% 100%);
   --foreground: hsl(240 10% 3.9%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .dark {
@@ -65,8 +79,22 @@
   --chart-3: hsl(30 80% 55%);
   --chart-4: hsl(280 65% 60%);
   --chart-5: hsl(340 75% 55%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .purple {
@@ -97,8 +125,22 @@
   --border: hsl(272 30% 88%);
   --input: hsl(272 30% 88%);
   --ring: hsl(272 60% 50%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .forest {
@@ -129,8 +171,22 @@
   --border: hsl(145 30% 75%);
   --input: hsl(145 30% 75%);
   --ring: hsl(145 60% 35%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .sunset {
@@ -161,8 +217,22 @@
   --border: hsl(24 30% 80%);
   --input: hsl(24 30% 80%);
   --ring: hsl(14 90% 55%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .ocean {
@@ -193,8 +263,22 @@
   --border: hsl(210 30% 85%);
   --input: hsl(210 30% 85%);
   --ring: hsl(210 100% 40%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .rose {
@@ -225,8 +309,22 @@
   --border: hsl(340 30% 85%);
   --input: hsl(340 30% 85%);
   --ring: hsl(340 65% 55%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .dunes {
@@ -257,8 +355,22 @@
   --border: hsl(37 48% 79%);
   --input: hsl(37 48% 79%);
   --ring: hsl(37 60% 57%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .amethyst {
@@ -269,7 +381,7 @@
   --popover: hsl(260 22% 10%);
   --popover-foreground: hsl(264 100% 95%);
   --primary: hsl(272 100% 74%);
-  --primary-foreground: hsl(260 22% 10%);
+  --primary-foreground: hsl(261, 59%, 89%);
   --secondary: hsl(266 25% 15%);
   --secondary-foreground: hsl(264 100% 95%);
   --muted: hsl(266 25% 15%);
@@ -281,8 +393,22 @@
   --border: hsl(266 25% 25%);
   --input: hsl(266 25% 25%);
   --ring: hsl(272 100% 74%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .abyss {
@@ -293,7 +419,7 @@
   --popover: hsl(212 58% 12%);
   --popover-foreground: hsl(174 40% 93%);
   --primary: hsl(177 54% 50%);
-  --primary-foreground: hsl(212 58% 12%);
+  --primary-foreground: hsl(0, 0%, 100%);
   --secondary: hsl(212 49% 15%);
   --secondary-foreground: hsl(174 40% 93%);
   --muted: hsl(212 49% 15%);
@@ -305,8 +431,22 @@
   --border: hsl(212 40% 22%);
   --input: hsl(212 40% 22%);
   --ring: hsl(177 54% 50%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .monochrome {
@@ -329,8 +469,22 @@
   --border: hsl(215 19% 35%);
   --input: hsl(215 19% 35%);
   --ring: hsl(210 40% 98%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .midnight {
@@ -353,8 +507,22 @@
   --border: hsl(220 12% 25%);
   --input: hsl(220 12% 25%);
   --ring: hsl(220 70% 60%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .crimson {
@@ -377,8 +545,22 @@
   --border: hsl(340 10% 25%);
   --input: hsl(340 10% 25%);
   --ring: hsl(340 65% 50%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 .cyberpunk {
@@ -409,8 +591,22 @@
   --border: hsl(260 12% 25%);
   --input: hsl(260 12% 25%);
   --ring: hsl(290 80% 60%);
-  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
-  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
+  --primary-gradient: linear-gradient(
+    to bottom right,
+    var(--primary),
+    var(--accent)
+  );
+  --ambient-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in srgb, var(--accent) 70%, transparent),
+    var(--background),
+    color-mix(in srgb, var(--secondary) 50%, transparent)
+  );
+  --card-gradient: linear-gradient(
+    to bottom right,
+    var(--card) 0%,
+    color-mix(in srgb, var(--primary) 10%, var(--card)) 100%
+  );
 }
 
 @theme inline {
@@ -440,6 +636,7 @@
   --color-chart-5: var(--chart-5);
   --background-image-gradient-primary: var(--primary-gradient);
   --background-image-gradient-ambient: var(--ambient-gradient);
+  --background-image-gradient-card: var(--card-gradient);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -481,7 +678,9 @@ input[type="number"] {
   }
 
   .peg {
-    box-shadow: 0 0 2px #fff000, 0 0 5px #fff !important;
+    box-shadow:
+      0 0 2px #fff000,
+      0 0 5px #fff !important;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,7 +36,10 @@
   --radius: 0.6rem;
   --background: hsl(0 0% 100%);
   --foreground: hsl(240 10% 3.9%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
+
 .dark {
   --background: hsl(240 10% 3.9%);
   --foreground: hsl(0 0% 98%);
@@ -62,6 +65,8 @@
   --chart-3: hsl(30 80% 55%);
   --chart-4: hsl(280 65% 60%);
   --chart-5: hsl(340 75% 55%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .purple {
@@ -92,6 +97,8 @@
   --border: hsl(272 30% 88%);
   --input: hsl(272 30% 88%);
   --ring: hsl(272 60% 50%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .forest {
@@ -122,6 +129,8 @@
   --border: hsl(145 30% 75%);
   --input: hsl(145 30% 75%);
   --ring: hsl(145 60% 35%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .sunset {
@@ -152,6 +161,8 @@
   --border: hsl(24 30% 80%);
   --input: hsl(24 30% 80%);
   --ring: hsl(14 90% 55%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .ocean {
@@ -182,6 +193,8 @@
   --border: hsl(210 30% 85%);
   --input: hsl(210 30% 85%);
   --ring: hsl(210 100% 40%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .rose {
@@ -212,6 +225,8 @@
   --border: hsl(340 30% 85%);
   --input: hsl(340 30% 85%);
   --ring: hsl(340 65% 55%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .dunes {
@@ -242,6 +257,8 @@
   --border: hsl(37 48% 79%);
   --input: hsl(37 48% 79%);
   --ring: hsl(37 60% 57%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .amethyst {
@@ -264,6 +281,8 @@
   --border: hsl(266 25% 25%);
   --input: hsl(266 25% 25%);
   --ring: hsl(272 100% 74%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .abyss {
@@ -286,6 +305,8 @@
   --border: hsl(212 40% 22%);
   --input: hsl(212 40% 22%);
   --ring: hsl(177 54% 50%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .monochrome {
@@ -308,6 +329,8 @@
   --border: hsl(215 19% 35%);
   --input: hsl(215 19% 35%);
   --ring: hsl(210 40% 98%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .midnight {
@@ -330,6 +353,8 @@
   --border: hsl(220 12% 25%);
   --input: hsl(220 12% 25%);
   --ring: hsl(220 70% 60%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .crimson {
@@ -352,6 +377,8 @@
   --border: hsl(340 10% 25%);
   --input: hsl(340 10% 25%);
   --ring: hsl(340 65% 50%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 .cyberpunk {
@@ -382,6 +409,8 @@
   --border: hsl(260 12% 25%);
   --input: hsl(260 12% 25%);
   --ring: hsl(290 80% 60%);
+  --primary-gradient: linear-gradient(to bottom right, var(--primary), var(--accent));
+  --ambient-gradient: linear-gradient(to bottom right, color-mix(in srgb, var(--accent) 70%, transparent), var(--background), color-mix(in srgb, var(--secondary) 50%, transparent));
 }
 
 @theme inline {
@@ -409,6 +438,8 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
+  --background-image-gradient-primary: var(--primary-gradient);
+  --background-image-gradient-ambient: var(--ambient-gradient);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -463,23 +494,23 @@ input[type="number"] {
 
 /* Webkit (Chrome, Safari, newer versions of Opera) */
 ::-webkit-scrollbar {
-  width: 4px; /* Width of the entire scrollbar */
+  width: 4px;
   height: 4px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--color-muted); /* Color of the tracking area */
+  background: var(--color-muted);
   border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--color-muted-foreground); /* Color of the scroll thumb */
+  background: var(--color-muted-foreground);
   border-radius: 10px;
   transition: background 0.3s ease;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--color-primary); /* Color when hovering over scroll thumb */
+  background: var(--color-primary);
 }
 
 /* Cloudinary Upload Widget compatibility inside Radix Modals & Drawers */

--- a/components/home/home-header.tsx
+++ b/components/home/home-header.tsx
@@ -55,19 +55,19 @@ export function HomeHeader() {
   if (loading) return <Skeleton className="h-44 rounded-md" />;
 
   return (
-    <Card className="relative overflow-hidden p-6 sm:p-7 bg-gradient-to-br from-primary to-primary/70 text-primary-foreground gap-4">
-      <div className="flex items-start justify-between gap-4">
+    <Card className="relative overflow-hidden p-6 sm:p-7 bg-gradient-primary text-primary-foreground gap-4 border-none shadow-xl">
+      <div className="flex items-start justify-between gap-4 z-10 relative">
         <div>
           <h1 className="text-2xl sm:text-3xl font-serif italic font-medium tracking-tight">
             {greet()}
           </h1>
-          <p className="text-sm opacity-80 mt-1">
+          <p className="text-sm opacity-90 mt-1">
             Here&apos;s what&apos;s happening at a glance.
           </p>
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2 pt-1">
+      <div className="flex flex-wrap gap-2 pt-1 z-10 relative">
         <StatChip
           icon={<ListChecks className="h-3.5 w-3.5" />}
           loading={taskLoading}
@@ -89,7 +89,7 @@ export function HomeHeader() {
       </div>
 
       <Image
-        className="absolute opacity-10 right-0 sm:right-10 top-1/2 -translate-y-1/2 w-1/2 sm:w-1/3 pointer-events-none"
+        className="absolute opacity-15 right-0 sm:right-10 top-1/2 -translate-y-1/2 w-1/2 sm:w-1/3 pointer-events-none mix-blend-overlay"
         src="/z_icon.webp"
         alt="logo"
         width={300}

--- a/components/home/jot-down.tsx
+++ b/components/home/jot-down.tsx
@@ -105,7 +105,7 @@ export function JotDown() {
             <Button
               disabled={isPending}
               type="submit"
-              className="max-sm:w-full"
+              className="max-sm:w-full bg-gradient-primary text-primary-foreground shadow-md hover:opacity-90 transition-opacity"
             >
               Submit
             </Button>

--- a/components/home/todays-focus.tsx
+++ b/components/home/todays-focus.tsx
@@ -22,7 +22,7 @@ export async function TodaysFocus() {
   const data = await getTodaysQuote();
 
   return (
-    <Card className="relative overflow-hidden p-6 sm:p-8 bg-gradient-to-br from-accent/60 to-accent/20 items-center text-center">
+    <Card className="relative overflow-hidden p-6 sm:p-8 bg-gradient-ambient border border-primary/10 shadow-sm items-center text-center">
       <span
         aria-hidden
         className="absolute -top-2 left-4 font-serif text-7xl text-primary/15 select-none"

--- a/components/landing-page/Logo.tsx
+++ b/components/landing-page/Logo.tsx
@@ -10,7 +10,7 @@ export const Logo = () => (
       alt=""
       className="shadow-md rounded-[18%]"
     />
-    <span className="text-4xl font-extrabold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+    <span className="text-4xl hidden sm:block font-extrabold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
       ZapJot
     </span>
   </Link>

--- a/components/landing-page/header/header.tsx
+++ b/components/landing-page/header/header.tsx
@@ -1,84 +1,13 @@
-"use client";
-
-import { useState } from "react";
 import { Logo } from "@/components/landing-page/Logo";
-import { Link } from "../../layout/link/CustomLink";
-import dynamic from "next/dynamic";
-import { Menu, X, Compass, Sparkles } from "lucide-react";
-
-const HeaderAction = dynamic(() => import("./header-action"), { ssr: false });
+import HeaderNavigation from "./navigation";
 
 export function Header() {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  const navLinks = [
-    { href: "/explore", label: "Explore Hub", highlight: true, icon: Compass },
-    { href: "/#features", label: "Features" },
-    { href: "/#how-it-works", label: "How It Works" },
-    { href: "/#pricing", label: "Pricing" },
-    { href: "/#contact", label: "Contact" },
-  ];
-
   return (
     <header className="sticky top-0 z-50 w-full h-16 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-purple-100/60 dark:border-slate-800 transition-all duration-300">
       <div className="container mx-auto h-full flex items-center justify-between px-4 md:px-6">
         <Logo />
-
-        {/* Desktop Navigation Links */}
-        <nav className="hidden md:flex items-center gap-6">
-          {navLinks.map((link) => {
-            const Icon = link.icon;
-            return (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={`text-sm font-semibold transition-all duration-200 flex items-center gap-1.5 ${
-                  link.highlight
-                    ? "px-3.5 py-1.5 rounded-full bg-purple-100 dark:bg-purple-950/60 text-purple-700 dark:text-purple-300 hover:bg-purple-200 shadow-xs border border-purple-200/50"
-                    : "text-slate-600 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-400"
-                }`}
-              >
-                {Icon && <Icon className="h-3.5 w-3.5" />}
-                {link.label}
-              </Link>
-            );
-          })}
-        </nav>
-
-        {/* Action Button & Mobile Menu Toggle */}
-        <div className="flex items-center gap-3">
-          <HeaderAction />
-
-          <button
-            type="button"
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            className="md:hidden p-2 rounded-xl bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-200 transition"
-            aria-label="Toggle menu"
-          >
-            {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-          </button>
-        </div>
+        <HeaderNavigation />
       </div>
-
-      {/* Mobile Navigation Dropdown */}
-      {mobileMenuOpen && (
-        <div className="md:hidden bg-white/95 dark:bg-slate-950/95 backdrop-blur-xl border-b border-purple-100 shadow-xl px-4 py-4 space-y-3 animate-in slide-in-from-top-2">
-          {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              onClick={() => setMobileMenuOpen(false)}
-              className={`block px-4 py-2.5 rounded-xl text-sm font-semibold transition ${
-                link.highlight
-                  ? "bg-purple-600 text-white font-bold"
-                  : "text-slate-700 dark:text-slate-200 hover:bg-purple-50 dark:hover:bg-purple-950/40"
-              }`}
-            >
-              {link.label}
-            </Link>
-          ))}
-        </div>
-      )}
     </header>
   );
 }

--- a/components/landing-page/header/login-button.tsx
+++ b/components/landing-page/header/login-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useAuth } from "@/lib/context/AuthProvider";
 import { Link } from "../../layout/link/CustomLink";
+import { LogIn } from "lucide-react";
 
 export default function LoginButton() {
   const { user } = useAuth();
@@ -9,9 +10,10 @@ export default function LoginButton() {
     !user && (
       <Link
         href="/auth/sign-in"
-        className="hidden md:inline-flex text-sm font-medium hover:text-primary transition-colors w-16"
+        className="hidden md:inline-flex text-sm font-medium transition-colors cursor-pointer px-4 py-2 rounded-md items-center gap-1 border border-primary text-primary hover:bg-secondary"
       >
-        Log in
+        Log In
+        <LogIn className="w-4 h-4" />
       </Link>
     )
   );

--- a/components/landing-page/header/navigation.tsx
+++ b/components/landing-page/header/navigation.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { Link } from "../../layout/link/CustomLink";
+import dynamic from "next/dynamic";
+import { Menu, X, Compass, LogIn } from "lucide-react";
+
+const HeaderAction = dynamic(() => import("./header-action"), { ssr: false });
+
+export default function HeaderNavigation() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const navLinks = [
+    { href: "/#features", label: "Features" },
+    { href: "/#how-it-works", label: "How It Works" },
+    { href: "/#pricing", label: "Pricing" },
+    { href: "/#contact", label: "Contact" },
+    { href: "/explore", label: "Explore Hub", highlight: true, icon: Compass },
+  ];
+
+  return (
+    <>
+      {/* Desktop Navigation Links */}
+      <nav className="hidden lg:flex items-center gap-6">
+        {navLinks.map((link) => {
+          const Icon = link.icon;
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`text-sm font-semibold transition-all duration-200 flex items-center gap-1.5 ${
+                link.highlight
+                  ? "px-3.5 py-1.5 rounded-full bg-purple-100 dark:bg-purple-950/60 text-purple-700 dark:text-purple-300 hover:bg-purple-200 shadow-xs border border-purple-200/50"
+                  : "text-slate-600 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-400"
+              }`}
+            >
+              {Icon && <Icon className="h-3.5 w-3.5" />}
+              {link.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Action Button & Mobile Menu Toggle */}
+      <div className="flex items-center gap-3">
+        <HeaderAction />
+
+        <button
+          type="button"
+          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          className="lg:hidden p-2 rounded-xl bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-200 transition"
+          aria-label="Toggle menu"
+        >
+          {mobileMenuOpen ? (
+            <X className="h-5 w-5" />
+          ) : (
+            <Menu className="h-5 w-5" />
+          )}
+        </button>
+      </div>
+      {/* Mobile Navigation Dropdown */}
+      {mobileMenuOpen && (
+        <div className="lg:hidden fixed w-full top-16 left-0 bg-white/95 dark:bg-slate-950/95 backdrop-blur-xl border-b border-purple-100 shadow-xl px-4 py-4 space-y-3 animate-in slide-in-from-top-2">
+          {navLinks.map((link) => {
+            const Icon = link.icon;
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setMobileMenuOpen(false)}
+                className={`flex items-center gap-2 px-4 py-2.5 rounded-md text-sm font-semibold transition ${
+                  link.highlight
+                    ? "bg-gradient-to-r from-purple-600 to-pink-600 text-white font-bold justify-center"
+                    : "text-slate-700 dark:text-slate-200 hover:bg-purple-50 dark:hover:bg-purple-950/40"
+                }`}
+              >
+                {Icon && <Icon className="h-3.5 w-3.5" />}
+
+                {link.label}
+              </Link>
+            );
+          })}
+          <Link
+            href="/auth/sign-in"
+            className="flex md:hidden text-sm font-medium transition-colors cursor-pointer px-4 py-2 rounded-md justify-center items-center gap-1 border border-primary text-primary hover:bg-secondary"
+          >
+            Log In
+            <LogIn className="w-4 h-4" />
+          </Link>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/layout/NavigationBar.tsx
+++ b/components/layout/NavigationBar.tsx
@@ -33,11 +33,11 @@ export function NavigationBar() {
               className={cn(
                 "relative flex flex-col items-center gap-1 p-2 text-muted-foreground transition-transform duration-200 hover:text-primary",
                 pathname.includes(route.href) &&
-                  "text-primary-foreground transform scale-110 transition-transform duration-200 bg-primary hover:bg-primary/90 hover:text-primary-foreground rounded-2xl",
+                  "text-primary-foreground transform scale-110 transition-transform duration-200 bg-gradient-primary hover:bg-primary/90 hover:text-primary-foreground rounded-2xl",
               )}
             >
               {/* {isActive && (
-          <div className="absolute w-16 h-16 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-primary rounded-full -z-10 transition-transform duration-200 scale-110" />
+          <div className="absolute w-16 h-16 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gradient-primary rounded-full -z-10 transition-transform duration-200 scale-110" />
         )} */}
               <route.icon className="h-5 w-5" />
               <span className="text-xs">{route.label}</span>
@@ -60,7 +60,7 @@ export function NavigationBar() {
             className={cn(
               "flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-colors hover:text-primary hover:bg-accent",
               pathname.includes(route.href) &&
-                "text-primary-foreground bg-primary hover:bg-primary/90 hover:text-primary-foreground",
+                "text-primary-foreground bg-gradient-primary hover:bg-primary/90 hover:text-primary-foreground",
             )}
           >
             <route.icon className="h-5 w-5" />

--- a/components/layout/NavigationBar.tsx
+++ b/components/layout/NavigationBar.tsx
@@ -25,24 +25,27 @@ export function NavigationBar() {
     // Smaller screen navigation (bottom bar)
     return (
       <nav className="fixed bottom-0 w-full border-t bg-background p-2 z-50 lg:hidden">
-        <div className="mx-auto grid grid-cols-6 container px-1">
-          {allRoutes.map((route) => (
-            <Link
-              key={route.href}
-              href={route.href}
-              className={cn(
-                "relative flex flex-col items-center gap-1 p-2 text-muted-foreground transition-transform duration-200 hover:text-primary",
-                pathname.includes(route.href) &&
-                  "text-primary-foreground transform scale-110 transition-transform duration-200 bg-gradient-primary hover:bg-primary/90 hover:text-primary-foreground rounded-2xl",
-              )}
-            >
-              {/* {isActive && (
+        <div className="mx-auto grid grid-cols-5 container px-1">
+          {allRoutes.map(
+            (route) =>
+              route.label !== "Settings" && (
+                <Link
+                  key={route.href}
+                  href={route.href}
+                  className={cn(
+                    "relative flex flex-col items-center gap-1 p-2 text-muted-foreground transition-transform duration-200 hover:text-primary",
+                    pathname.includes(route.href) &&
+                      "text-primary-foreground transform scale-110 transition-transform duration-200 bg-gradient-primary hover:bg-primary/90 hover:text-primary-foreground rounded-2xl",
+                  )}
+                >
+                  {/* {isActive && (
           <div className="absolute w-16 h-16 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gradient-primary rounded-full -z-10 transition-transform duration-200 scale-110" />
         )} */}
-              <route.icon className="h-5 w-5" />
-              <span className="text-xs">{route.label}</span>
-            </Link>
-          ))}
+                  <route.icon className="h-5 w-5" />
+                  <span className="text-xs">{route.label}</span>
+                </Link>
+              ),
+          )}
         </div>
       </nav>
     );

--- a/components/layout/page-header.tsx
+++ b/components/layout/page-header.tsx
@@ -12,6 +12,7 @@ export interface PageHeaderProps {
   backLink?: string;
   className?: string;
   showSearch?: boolean;
+  onBackClick?: () => void;
   onSearchClick?: () => void;
 }
 
@@ -24,13 +25,14 @@ export function PageHeader({
   className,
   showSearch = false,
   onSearchClick,
+  onBackClick,
 }: PageHeaderProps) {
   return (
     <div className={cn("flex flex-col gap-1 py-4 border-b mb-6", className)}>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 flex-1 min-w-0">
-          {backLink && (
-            <Link href={backLink} className="mr-1">
+          {(backLink || onBackClick) && (
+            <Link href={backLink} className="mr-1" onClick={onBackClick}>
               <Button
                 variant="ghost"
                 size="icon"

--- a/components/planner/Planner.tsx
+++ b/components/planner/Planner.tsx
@@ -72,25 +72,25 @@ export default function PlannerPage() {
     >
       <TabsList className="grid w-full grid-cols-4 bg-muted/50 md:h-16 mb-2 gap-1 p-1">
         <TabsTrigger
-          className="md:flex-col md:h-12 md:gap-1 rounded-md data-[state=active]:shadow-sm data-[state=active]:bg-card data-[state=active]:text-primary transition-colors"
+          className="md:flex-col md:h-12 md:gap-1 rounded-lg data-[state=active]:shadow-md data-[state=active]:bg-gradient-primary data-[state=active]:text-primary-foreground font-semibold transition-all duration-200"
           value="tasks"
         >
           <ListCheck className="h-4 w-4" /> Tasks
         </TabsTrigger>
         <TabsTrigger
-          className="md:flex-col md:h-12 md:gap-1 rounded-md data-[state=active]:shadow-sm data-[state=active]:bg-card data-[state=active]:text-primary transition-colors"
+          className="md:flex-col md:h-12 md:gap-1 rounded-lg data-[state=active]:shadow-md data-[state=active]:bg-gradient-primary data-[state=active]:text-primary-foreground font-semibold transition-all duration-200"
           value="events"
         >
           <CalendarCheck className="h-4 w-4" /> Events
         </TabsTrigger>
         <TabsTrigger
-          className="md:flex-col md:h-12 md:gap-1 rounded-md data-[state=active]:shadow-sm data-[state=active]:bg-card data-[state=active]:text-primary transition-colors"
+          className="md:flex-col md:h-12 md:gap-1 rounded-lg data-[state=active]:shadow-md data-[state=active]:bg-gradient-primary data-[state=active]:text-primary-foreground font-semibold transition-all duration-200"
           value="goals"
         >
           <Goal className="h-4 w-4" /> Goals
         </TabsTrigger>
         <TabsTrigger
-          className="md:flex-col md:h-12 md:gap-1 rounded-md data-[state=active]:shadow-sm data-[state=active]:bg-card data-[state=active]:text-primary transition-colors"
+          className="md:flex-col md:h-12 md:gap-1 rounded-lg data-[state=active]:shadow-md data-[state=active]:bg-gradient-primary data-[state=active]:text-primary-foreground font-semibold transition-all duration-200"
           value="itineraries"
         >
           <LandPlot className="h-4 w-4" />

--- a/components/planner/events/EventCard.tsx
+++ b/components/planner/events/EventCard.tsx
@@ -27,7 +27,7 @@ export function EventCard({
     <ListCard onClick={onClick} className="cursor-pointer">
       <CardContent className="px-4 py-2 gap-1">
         <div className="flex justify-between items-center">
-          <h3 className="text-lg font-semibold text-primary truncate">
+          <h3 className="text-lg font-semibold truncate">
             {event.title}
           </h3>
 

--- a/components/planner/itineraries/BudgetSummary.tsx
+++ b/components/planner/itineraries/BudgetSummary.tsx
@@ -48,12 +48,12 @@ export function BudgetSummary({ itinerary }: { itinerary: Itinerary }) {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Card className="border-muted gap-0">
+        <Card className="bg-gradient-primary text-primary-foreground border-none shadow-md gap-0">
           <CardHeader className="px-4 pt-2">
-            <CardTitle className="text-lg">Planned Budget</CardTitle>
+            <CardTitle className="text-lg text-primary-foreground/90">Planned Budget</CardTitle>
           </CardHeader>
           <CardContent className="px-4 py-2">
-            <p className="text-3xl font-bold">
+            <p className="text-3xl font-extrabold">
               ${itinerary.budget?.toLocaleString()}
             </p>
           </CardContent>

--- a/components/planner/itineraries/ItineraryDetailCard.tsx
+++ b/components/planner/itineraries/ItineraryDetailCard.tsx
@@ -341,14 +341,14 @@ const ItineraryDetailCard: React.FC<ItineraryDetailProps> = ({
               </Button>
             </div>
           </div>
-          <div className="text-sm flex justify-between items-center gap-2 pt-0.5">
+          <div className="text-sm flex justify-between items-end gap-2 pt-0.5">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-xs sm:text-sm font-medium text-foreground/90 flex items-center gap-1">
+              <span className="text-xs sm:text-sm font-medium text-foreground flex items-center gap-1">
                 <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
                 {formatDate(itinerary.startDate)}
                 {itinerary.endDate &&
                   itinerary.endDate !== itinerary.startDate && (
-                    <span className="text-muted-foreground">
+                    <span className="">
                       - {formatDate(itinerary.endDate)}
                     </span>
                   )}

--- a/components/planner/tasks/TaskCard.tsx
+++ b/components/planner/tasks/TaskCard.tsx
@@ -33,7 +33,14 @@ export function TaskCard({
   };
 
   return (
-    <ListCard key={task.id}>
+    <ListCard
+      key={task.id}
+      className={cn(
+        task.highPriority
+          ? "bg-gradient-to-r from-primary/10 via-card to-card border-l-primary"
+          : ""
+      )}
+    >
       <CardContent className="px-4 py-2 gap-1">
         <div className="w-full flex justify-between items-center space-x-2">
           <span className="flex items-center space-x-2">

--- a/components/planner/tasks/TaskCard.tsx
+++ b/components/planner/tasks/TaskCard.tsx
@@ -37,7 +37,7 @@ export function TaskCard({
       key={task.id}
       className={cn(
         task.highPriority
-          ? "bg-gradient-to-r from-primary/10 via-card to-card border-l-primary"
+          ? "bg-gradient-to-r from-primary/20 via-card to-card border-l-primary"
           : ""
       )}
     >

--- a/components/settings/SettingsPage.tsx
+++ b/components/settings/SettingsPage.tsx
@@ -1,45 +1,108 @@
+"use client";
 import { Separator } from "@/components/ui/separator";
 import { NotificationSettings } from "./NotificationsSettings";
 import ThemesPage from "./themes/ThemeSelectorAdv";
 import { AiSettings } from "./AiSettings";
-import { Bot, Calendar } from "lucide-react";
+import { Bot, Calendar, ChevronRight, Palette, UserCog } from "lucide-react";
 import { GoogleCalendarSettings } from "./GoogleCalendarSettings";
+import { useEffect, useState } from "react";
+import Account from "../account/Account";
+import PageLayout from "../layout/PageLayout";
 
 export default function SettingsPage() {
+  const [activeTab, setActiveTab] = useState<string | null>(null);
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [activeTab]);
+
   return (
-    <div className="container max-w-4xl space-y-8 pb-20">
-      <div>
-        <div className="flex items-center gap-2 mb-4">
-          <Bot className="h-6 w-6 text-primary" />
-          <h2 className="text-xl font-bold">AI Assistance</h2>
-        </div>
-        <AiSettings />
+    <PageLayout
+      headerProps={{
+        title: activeTab
+          ? activeTab.charAt(0).toUpperCase() + activeTab.slice(1)
+          : "Settings",
+        onBackClick: () => {
+          setActiveTab(null);
+        },
+        ...(!activeTab ? { backLink: "/home" } : {}),
+      }}
+    >
+      <div className="container max-w-4xl space-y-8 pb-20 mx-auto">
+        {activeTab === "themes" ? (
+          <ThemesPage />
+        ) : activeTab === "account" ? (
+          <Account />
+        ) : (
+          <>
+            <div>
+              <div className="flex items-center gap-2 mb-4">
+                <Bot className="h-6 w-6 text-primary" />
+                <h2 className="text-xl font-bold">AI Assistance</h2>
+              </div>
+              <AiSettings />
+            </div>
+
+            <Separator />
+
+            <div>
+              <h2 className="text-xl font-bold mb-4">
+                Notification Preferences
+              </h2>
+              <NotificationSettings />
+            </div>
+
+            <Separator />
+
+            <div>
+              <div className="flex items-center gap-2 mb-4">
+                <Calendar className="h-6 w-6 text-primary" />
+                <h2 className="text-xl font-bold">Google Calendar Sync</h2>
+              </div>
+              <GoogleCalendarSettings />
+            </div>
+
+            <Separator />
+
+            <div>
+              <h2 className="text-xl font-bold mb-4">Appearance</h2>
+              <div
+                className="flex items-center justify-between rounded-lg border p-4 transition-all duration-200"
+                onClick={() => setActiveTab("themes")}
+              >
+                <div className="flex items-center gap-3">
+                  <Palette className="h-5 w-5" />
+                  <div className="space-y-1">
+                    <div className="text-base font-semibold">Themes</div>
+                    <div className="text-sm">
+                      Choose a theme for your application.
+                    </div>
+                  </div>
+                </div>
+                <ChevronRight className="h-5 w-5" />
+              </div>
+            </div>
+
+            <Separator />
+
+            <div>
+              <h2 className="text-xl font-bold mb-4">Account</h2>
+              <div
+                className="flex items-center justify-between rounded-lg border p-4 transition-all duration-200"
+                onClick={() => setActiveTab("account")}
+              >
+                <div className="flex items-center gap-3">
+                  <UserCog className="h-5 w-5" />
+                  <div className="space-y-1">
+                    <div className="text-base font-semibold">Account</div>
+                    <div className="text-sm">Manage your account settings.</div>
+                  </div>
+                </div>
+                <ChevronRight className="h-5 w-5" />
+              </div>
+            </div>
+          </>
+        )}
       </div>
-
-      <Separator />
-
-      <div>
-        <h2 className="text-xl font-bold mb-4">Notification Preferences</h2>
-        <NotificationSettings />
-      </div>
-
-      <Separator />
-
-      <div>
-        <div className="flex items-center gap-2 mb-4">
-          <Calendar className="h-6 w-6 text-primary" />
-          <h2 className="text-xl font-bold">Google Calendar Sync</h2>
-        </div>
-        <GoogleCalendarSettings />
-      </div>
-
-      <Separator />
-
-      <div>
-        <h2 className="text-xl font-bold mb-4">Appearance</h2>
-        <ThemesPage />
-      </div>
-    </div>
+    </PageLayout>
   );
 }
-

--- a/components/settings/themes/ThemeCard.tsx
+++ b/components/settings/themes/ThemeCard.tsx
@@ -25,8 +25,10 @@ export function ThemeCard({
 
   return (
     <Card
-      className={`cursor-pointer flex flex-col rounded-md border-2 ${
-        isActive ? "border-primary" : "border-muted"
+      className={`cursor-pointer flex flex-col rounded-xl border-2 transition-all duration-300 ${
+        isActive
+          ? "border-primary shadow-lg ring-2 ring-primary/30"
+          : "border-muted/70 hover:border-primary/40"
       } overflow-hidden`}
       onClick={() => onThemeSelect(theme.id)}
       style={{
@@ -46,9 +48,20 @@ export function ThemeCard({
             height={44}
             alt="logo"
             color={colors.primary}
-            className={"shadow-md rounded-[18%]"}
+            className={"shadow-sm rounded-[18%]"}
           />
-          <span>{theme.name}</span>
+          <span className="font-bold text-sm">{theme.name}</span>
+          {isActive && (
+            <span
+              className="ml-1 text-[10px] px-2 py-0.5 rounded-full font-bold uppercase tracking-wider"
+              style={{
+                backgroundColor: colors.primary,
+                color: colors.background,
+              }}
+            >
+              Active
+            </span>
+          )}
         </div>
         {theme.type === "custom" && (
           <div className="flex gap-2">

--- a/components/settings/themes/ThemeCard.tsx
+++ b/components/settings/themes/ThemeCard.tsx
@@ -33,6 +33,7 @@ export function ThemeCard({
       onClick={() => onThemeSelect(theme.id)}
       style={{
         backgroundColor: colors.background,
+        backgroundImage: colors.cardGradient,
         color: colors.foreground,
       }}
     >

--- a/components/settings/themes/ThemePreview.tsx
+++ b/components/settings/themes/ThemePreview.tsx
@@ -42,18 +42,21 @@ export function ThemePreview({ colors }: ThemePreviewProps) {
       </div>
 
       <div className="grid grid-cols-3 gap-2">
-        {Object.entries(colors).map(([key, value]) => (
-          <div key={key} className="flex flex-col items-center">
-            <div
-              className="w-6 h-6 rounded-full border shadow-xs"
-              style={{
-                background: value || gradientStyle,
-                borderColor: colors.border,
-              }}
-            />
-            <span className="text-[11px] mt-1 opacity-80">{key}</span>
-          </div>
-        ))}
+        {Object.entries(colors).map(
+          ([key, value]) =>
+            key !== "cardGradient" && (
+              <div key={key} className="flex flex-col items-center">
+                <div
+                  className="w-6 h-6 rounded-full border shadow-xs"
+                  style={{
+                    background: value || gradientStyle,
+                    borderColor: colors.border,
+                  }}
+                />
+                <span className="text-[11px] mt-1 opacity-80">{key}</span>
+              </div>
+            ),
+        )}
       </div>
 
       {/* Theme Gradient Strip Banner */}

--- a/components/settings/themes/ThemePreview.tsx
+++ b/components/settings/themes/ThemePreview.tsx
@@ -5,11 +5,15 @@ interface ThemePreviewProps {
 }
 
 export function ThemePreview({ colors }: ThemePreviewProps) {
+  const gradientStyle =
+    colors.gradient ||
+    `linear-gradient(135deg, ${colors.primary}, ${colors.accent || colors.secondary})`;
+
   return (
     <div className="p-4">
-      <div className="flex space-x-2 mb-3">
+      <div className="flex flex-wrap gap-2 mb-3">
         <button
-          className="px-3 py-1 rounded-md text-xs"
+          className="px-3 py-1 rounded-md text-xs font-medium shadow-xs"
           style={{
             backgroundColor: colors.primary,
             color: invertColor(colors.primary),
@@ -18,7 +22,7 @@ export function ThemePreview({ colors }: ThemePreviewProps) {
           Primary
         </button>
         <button
-          className="px-3 py-1 rounded-md text-xs"
+          className="px-3 py-1 rounded-md text-xs font-medium shadow-xs"
           style={{
             backgroundColor: colors.secondary,
             color: colors.foreground,
@@ -26,21 +30,47 @@ export function ThemePreview({ colors }: ThemePreviewProps) {
         >
           Secondary
         </button>
+        <button
+          className="px-3 py-1 rounded-md text-xs font-medium shadow-xs"
+          style={{
+            background: gradientStyle,
+            color: invertColor(colors.primary),
+          }}
+        >
+          Gradient
+        </button>
       </div>
 
       <div className="grid grid-cols-3 gap-2">
         {Object.entries(colors).map(([key, value]) => (
           <div key={key} className="flex flex-col items-center">
             <div
-              className="w-6 h-6 rounded-full border"
+              className="w-6 h-6 rounded-full border shadow-xs"
               style={{
-                backgroundColor: value,
+                background: value || gradientStyle,
                 borderColor: colors.border,
               }}
             />
-            <span className="text-xs mt-1">{key}</span>
+            <span className="text-[11px] mt-1 opacity-80">{key}</span>
           </div>
         ))}
+      </div>
+
+      {/* Theme Gradient Strip Banner */}
+      <div
+        className="mt-3 pt-2 border-t"
+        style={{ borderColor: colors.border }}
+      >
+        <div
+          className="w-full h-3.5 rounded-full border shadow-xs"
+          style={{
+            background: gradientStyle,
+            borderColor: colors.border,
+          }}
+        />
+        <span className="block text-[10px] text-center mt-1 font-semibold uppercase tracking-wider opacity-60">
+          Theme Gradient Accent
+        </span>
       </div>
     </div>
   );

--- a/components/social-card/PublicShareCard.tsx
+++ b/components/social-card/PublicShareCard.tsx
@@ -149,7 +149,7 @@ export const PublicShareCard: React.FC<PublicShareCardProps> = ({
         {!demo && (
           <div className="flex items-center justify-between gap-2 pt-1">
             <Link
-              href={`/share/${share.id}`}
+              href={`/explore/${share.id}`}
               className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl bg-white/15 hover:bg-white/25 text-white text-xs font-bold transition border border-white/20 backdrop-blur-md"
             >
               <BookOpen className="h-3.5 w-3.5 text-purple-200" />

--- a/components/social-card/PublicShareCard.tsx
+++ b/components/social-card/PublicShareCard.tsx
@@ -42,7 +42,7 @@ export const PublicShareCard: React.FC<PublicShareCardProps> = ({
 
   return (
     <div
-      className={`group relative flex flex-col justify-between ${selectedTheme.bg} p-5 sm:p-6 rounded-xl shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-1 overflow-hidden font-sans border border-white/15 min-h-[300px] text-white`}
+      className={`group relative flex flex-col justify-between ${selectedTheme.bg} p-4 rounded-xl shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-1 overflow-hidden font-sans border border-white/15 min-h-[300px] text-white`}
     >
       {/* Subtle background blur accents */}
       <div className="absolute -top-12 -right-12 w-40 h-40 bg-white/10 rounded-full blur-2xl pointer-events-none" />

--- a/components/social-card/SocialCardCanvas.tsx
+++ b/components/social-card/SocialCardCanvas.tsx
@@ -75,7 +75,7 @@ export const SocialCardCanvas = React.forwardRef<
     return (
       <div
         ref={ref}
-        className={`w-full max-w-full aspect-[4/5] ${selectedTheme.bg} p-6 sm:p-8 rounded-3xl shadow-2xl flex flex-col justify-between relative overflow-hidden font-sans border border-white/10`}
+        className={`w-full max-w-full aspect-[4/5] ${selectedTheme.bg} p-6 sm:p-8 shadow-2xl flex flex-col justify-between relative overflow-hidden font-sans border border-white/10`}
       >
         {/* Subtle background blur accents */}
         <div className="absolute -top-12 -right-12 w-48 h-48 bg-white/10 rounded-full blur-3xl pointer-events-none" />

--- a/components/social-card/SocialCardModal.tsx
+++ b/components/social-card/SocialCardModal.tsx
@@ -12,7 +12,11 @@ import {
 import { toast } from "@/components/ui/sonner";
 import { SocialCardCanvas, CardTheme, THEME_PRESETS } from "./SocialCardCanvas";
 import { useAuth } from "@/lib/context/AuthProvider";
-import { createPublicShare, getShareId } from "@/lib/services/publicShares";
+import {
+  createPublicShare,
+  getShareId,
+  PublicShare,
+} from "@/lib/services/publicShares";
 
 import Image from "next/image";
 
@@ -62,7 +66,7 @@ export const SocialCardModal: React.FC<SocialCardModalProps> = ({
         user.displayName || user.email?.split("@")[0] || "ZapJot User";
       const authorPhoto = user.photoURL || undefined;
 
-      const payload: any = {
+      const payload: Omit<PublicShare, "userId" | "createdAt" | "updatedAt"> = {
         id: shareId,
         type,
         title,
@@ -80,6 +84,7 @@ export const SocialCardModal: React.FC<SocialCardModalProps> = ({
           rawItem?.location ||
           subtitle?.replace("📍 ", "");
       if (rawItem?.days) payload.days = rawItem.days;
+      if (rawItem?.budget) payload.budget = rawItem.budget;
       payload.theme = selectedTheme;
 
       const publicDoc = await createPublicShare(user.uid, payload);
@@ -221,7 +226,7 @@ export const SocialCardModal: React.FC<SocialCardModalProps> = ({
           </div>
 
           {/* Card Canvas Live Preview */}
-          <div className="w-full flex justify-center py-2 bg-muted/40 rounded-2xl p-4 border border-border">
+          <div className="w-full flex justify-center bg-muted/40 rounded-2xl p-4 border border-border">
             <SocialCardCanvas
               ref={cardRef}
               title={title}

--- a/components/social-card/SocialCardModal.tsx
+++ b/components/social-card/SocialCardModal.tsx
@@ -84,7 +84,7 @@ export const SocialCardModal: React.FC<SocialCardModalProps> = ({
 
       const publicDoc = await createPublicShare(user.uid, payload);
 
-      const publicUrl = `${window.location.origin}/share/${publicDoc.id}`;
+      const publicUrl = `${window.location.origin}/explore/${publicDoc.id}`;
 
       if (typeof navigator !== "undefined" && navigator.clipboard) {
         await navigator.clipboard.writeText(publicUrl);

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,0 +1,109 @@
+import * as React from "react"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils/index"
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm break-words text-muted-foreground sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "a"
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-gradient-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -82,8 +82,9 @@ function ListCard({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-2 rounded-xl border shadow-sm",
-        "h-full overflow-hidden hover:shadow-md transition-all border-l-4 border-l-primary/20 hover:border-l-primary",
+        "bg-card text-card-foreground flex flex-col gap-2 rounded-xl border border-border/80 shadow-xs",
+        "h-full overflow-hidden hover:shadow-md transition-all duration-300",
+        "border-l-4 border-l-primary/40 hover:border-l-primary hover:bg-gradient-to-r hover:from-primary/5 hover:via-card hover:to-card",
         className
       )}
       {...props}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -5,7 +5,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col rounded-xl border shadow-sm",
+        "bg-card text-card-foreground bg-gradient-card flex flex-col rounded-xl border shadow-sm transition-all duration-300",
         className
       )}
       {...props}
@@ -82,7 +82,7 @@ function ListCard({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-2 rounded-xl border border-border/80 shadow-xs",
+        "bg-gradient-ambient text-card-foreground flex flex-col gap-2 rounded-xl border border-primary/10 shadow-xs",
         "h-full overflow-hidden hover:shadow-md transition-all duration-300",
         "border-l-4 border-l-primary/40 hover:border-l-primary hover:bg-gradient-to-r hover:from-primary/5 hover:via-card hover:to-card",
         className

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -42,10 +42,12 @@ export const defaultThemes: Theme[] = [
       foreground: "#0F1729",
       primary: "#1E293B",
       secondary: "#F1F5F9",
-      gradient: "linear-gradient(135deg, #1E293B 0%, #F1F5F9 100%)",
       accent: "#F1F5F9",
       muted: "#F1F5F9",
       border: "#E2E8F0",
+      gradient: "linear-gradient(135deg, #1E293B 0%, #F1F5F9 100%)",
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #F1F5F9 70%, transparent), #FFFFFF, color-mix(in srgb, #F1F5F9 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #FFFFFF 0%, color-mix(in srgb, #F1F5F9 15%, #FFFFFF) 100%)",
     },
   },
   {
@@ -53,14 +55,16 @@ export const defaultThemes: Theme[] = [
     name: "Dark",
     type: "basic",
     colors: {
-      background: "#09090B", // hsl(240 10% 3.9%)
-      foreground: "#FAFAFA", // hsl(0 0% 98%)
-      primary: "#FAFAFA", // hsl(0 0% 98%)
-      secondary: "#1E1E2A", // hsl(240 3.7% 15.9%)
+      background: "#09090B",
+      foreground: "#FAFAFA",
+      primary: "#FAFAFA",
+      secondary: "#1E1E2A",
+      accent: "#1E1E2A",
+      muted: "#1E1E2A",
+      border: "#1E1E2A",
       gradient: "linear-gradient(135deg, #FAFAFA 0%, #1E1E2A 100%)",
-      accent: "#1E1E2A", // hsl(240 3.7% 15.9%)
-      muted: "#1E1E2A", // hsl(240 3.7% 15.9%)
-      border: "#1E1E2A", // hsl(240 3.7% 15.9%)
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #1E1E2A 70%, transparent), #09090B, color-mix(in srgb, #1E1E2A 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #09090B 0%, color-mix(in srgb, #1E1E2A 15%, #09090B) 100%)",
     },
   },
   {
@@ -68,14 +72,16 @@ export const defaultThemes: Theme[] = [
     name: "System",
     type: "basic",
     colors: {
-      background: "#09090B", // hsl(240 10% 3.9%)
-      foreground: "#FAFAFA", // hsl(0 0% 98%)
-      primary: "#FAFAFA", // hsl(0 0% 98%)
-      secondary: "#1E1E2A", // hsl(240 3.7% 15.9%)
+      background: "#09090B",
+      foreground: "#FAFAFA",
+      primary: "#FAFAFA",
+      secondary: "#1E1E2A",
+      accent: "#1E1E2A",
+      muted: "#1E1E2A",
+      border: "#1E1E2A",
       gradient: "linear-gradient(135deg, #FAFAFA 0%, #1E1E2A 100%)",
-      accent: "#1E1E2A", // hsl(240 3.7% 15.9%)
-      muted: "#1E1E2A", // hsl(240 3.7% 15.9%)
-      border: "#1E1E2A", // hsl(240 3.7% 15.9%)
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #1E1E2A 70%, transparent), #09090B, color-mix(in srgb, #1E1E2A 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #09090B 0%, color-mix(in srgb, #1E1E2A 15%, #09090B) 100%)",
     },
   },
   {
@@ -83,14 +89,16 @@ export const defaultThemes: Theme[] = [
     name: "Purple",
     type: "light",
     colors: {
-      background: "#FAF7FC", // hsl(280 50% 98%)",
-      foreground: "#291839", // hsl(272 40% 16%)",
-      primary: "#8432CC", // hsl(272 60% 50%)",
-      secondary: "#E7DBEF", // hsl(275 40% 90%)",
+      background: "#FAF7FC",
+      foreground: "#291839",
+      primary: "#8432CC",
+      secondary: "#E7DBEF",
+      accent: "#E1D7E9",
+      muted: "#E7DBEF",
+      border: "#E1D7E9",
       gradient: "linear-gradient(135deg, #8432CC 0%, #E1D7E9 100%)",
-      accent: "#E1D7E9", // hsl(272 30% 88%)",
-      muted: "#E7DBEF", // hsl(275 40% 90%)",
-      border: "#E1D7E9", // hsl(272 30% 88%)",
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #E1D7E9 70%, transparent), #FAF7FC, color-mix(in srgb, #E7DBEF 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #FAF7FC 0%, color-mix(in srgb, #E1D7E9 15%, #FAF7FC) 100%)",
     },
   },
   {
@@ -98,14 +106,16 @@ export const defaultThemes: Theme[] = [
     name: "Rose",
     type: "light",
     colors: {
-      background: "#FCF7F9", // hsl(340 50% 98%)",
-      foreground: "#311A22", // hsl(340 30% 15%)",
-      primary: "#D64173", // hsl(340 65% 55%)",
-      secondary: "#EFDBE2", // hsl(340 40% 90%)",
+      background: "#FCF7F9",
+      foreground: "#311A22",
+      primary: "#D64173",
+      secondary: "#EFDBE2",
+      accent: "#E4CDD4",
+      muted: "#E8C9D3",
+      border: "#E4CDD4",
       gradient: "linear-gradient(135deg, #D64173 0%, #E4CDD4 100%)",
-      accent: "#E4CDD4", // hsl(340 30% 85%)",
-      muted: "#E8C9D3", // hsl(340 40% 85%)",
-      border: "#E4CDD4", // hsl(340 30% 85%)",
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #E4CDD4 70%, transparent), #FCF7F9, color-mix(in srgb, #EFDBE2 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #FCF7F9 0%, color-mix(in srgb, #E4CDD4 15%, #FCF7F9) 100%)",
     },
   },
   {
@@ -113,14 +123,16 @@ export const defaultThemes: Theme[] = [
     name: "Ocean",
     type: "light",
     colors: {
-      background: "#F7F9FC", // hsl(210 50% 98%)",
-      foreground: "#0E1629", // hsl(222 47% 11%)",
-      primary: "#0065CC", // hsl(210 100% 40%)",
-      secondary: "#DBE5EF", // hsl(210 40% 90%)",
+      background: "#F7F9FC",
+      foreground: "#0E1629",
+      primary: "#0065CC",
+      secondary: "#DBE5EF",
+      accent: "#CDD8E4",
+      muted: "#CDD8E4",
+      border: "#CDD8E4",
       gradient: "linear-gradient(135deg, #0065CC 0%, #CDD8E4 100%)",
-      accent: "#CDD8E4", // hsl(210 30% 85%)",
-      muted: "#CDD8E4", // hsl(210 30% 85%)",
-      border: "#CDD8E4", // hsl(210 30% 85%)",
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #CDD8E4 70%, transparent), #F7F9FC, color-mix(in srgb, #DBE5EF 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #F7F9FC 0%, color-mix(in srgb, #CDD8E4 15%, #F7F9FC) 100%)",
     },
   },
   {
@@ -128,14 +140,16 @@ export const defaultThemes: Theme[] = [
     name: "Forest",
     type: "light",
     colors: {
-      background: "#EDF6ED", // hsl(145 30% 95%)
-      foreground: "#1F3F1F", // hsl(145 50% 10%)
-      primary: "#2F8F2F", // hsl(145 60% 35%)
-      secondary: "#D5EAD5", // hsl(145 30% 85%)
+      background: "#EDF6ED",
+      foreground: "#1F3F1F",
+      primary: "#2F8F2F",
+      secondary: "#D5EAD5",
+      accent: "#AAD4AA",
+      muted: "#C2D9C2",
+      border: "#A8C8A8",
       gradient: "linear-gradient(135deg, #2F8F2F 0%, #AAD4AA 100%)",
-      accent: "#AAD4AA", // hsl(145 40% 75%)
-      muted: "#C2D9C2", // hsl(145 20% 80%)
-      border: "#A8C8A8", // hsl(145 30% 75%)
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #AAD4AA 70%, transparent), #EDF6ED, color-mix(in srgb, #D5EAD5 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #EDF6ED 0%, color-mix(in srgb, #AAD4AA 15%, #EDF6ED) 100%)",
     },
   },
   {
@@ -143,14 +157,16 @@ export const defaultThemes: Theme[] = [
     name: "Sunset",
     type: "light",
     colors: {
-      background: "#FFF5EF", // hsl(24 100% 97%)",
-      foreground: "#352116", // hsl(20 40% 15%)",
-      primary: "#F35524", // hsl(14 90% 55%)",
-      secondary: "#F9E1D1", // hsl(24 80% 90%)",
+      background: "#FFF5EF",
+      foreground: "#352116",
+      primary: "#F35524",
+      secondary: "#F9E1D1",
+      accent: "#EAC5AD",
+      muted: "#E8D5C9",
+      border: "#DBC8BC",
       gradient: "linear-gradient(135deg, #F35524 0%, #EAC5AD 100%)",
-      accent: "#EAC5AD", // hsl(24 60% 80%)",
-      muted: "#E8D5C9", // hsl(24 40% 85%)",
-      border: "#DBC8BC", // hsl(24 30% 80%)",
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #EAC5AD 70%, transparent), #FFF5EF, color-mix(in srgb, #F9E1D1 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #FFF5EF 0%, color-mix(in srgb, #EAC5AD 15%, #FFF5EF) 100%)",
     },
   },
   {
@@ -158,14 +174,16 @@ export const defaultThemes: Theme[] = [
     name: "Dunes",
     type: "light",
     colors: {
-      background: "#FDF8F0", // pale sand
-      foreground: "#3A2E21", // deep desert brown
-      primary: "#D2A052", // golden sand
-      secondary: "#F2E8D9", // light sand
+      background: "#FDF8F0",
+      foreground: "#3A2E21",
+      primary: "#D2A052",
+      secondary: "#F2E8D9",
+      accent: "#E1CEB3",
+      muted: "#F2E8D9",
+      border: "#E1CEB3",
       gradient: "linear-gradient(135deg, #D2A052 0%, #E1CEB3 100%)",
-      accent: "#E1CEB3", // medium sand/khaki
-      muted: "#F2E8D9", // light sand
-      border: "#E1CEB3", // medium sand/khaki
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #E1CEB3 70%, transparent), #FDF8F0, color-mix(in srgb, #F2E8D9 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #FDF8F0 0%, color-mix(in srgb, #E1CEB3 15%, #FDF8F0) 100%)",
     },
   },
 
@@ -175,46 +193,50 @@ export const defaultThemes: Theme[] = [
     name: "Amethyst",
     type: "dark",
     colors: {
-      background: "#17131F", // deep purple-black
-      foreground: "#F2EBFF", // light purple-white
-      primary: "#B87AFF", // bright purple
-      secondary: "#241B2F", // slightly lighter purple-black
+      background: "#17131F",
+      foreground: "#F2EBFF",
+      primary: "#B87AFF",
+      secondary: "#241B2F",
+      accent: "#6C40B5",
+      muted: "#241B2F",
+      border: "#352644",
       gradient: "linear-gradient(135deg, #B87AFF 0%, #6C40B5 100%)",
-      accent: "#6C40B5", // medium purple
-      muted: "#241B2F", // slightly lighter purple-black
-      border: "#352644", // medium purple
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #6C40B5 70%, transparent), #17131F, color-mix(in srgb, #241B2F 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #17131F 0%, color-mix(in srgb, #6C40B5 15%, #17131F) 100%)",
     },
   },
-
   {
     id: "abyss",
     name: "Abyss",
     type: "dark",
     colors: {
-      background: "#0A1A2F", // deep sea blue
-      foreground: "#E6F4F1", // seafoam white
-      primary: "#38C7BD", // teal
-      secondary: "#122339", // slightly lighter blue
+      background: "#0A1A2F",
+      foreground: "#E6F4F1",
+      primary: "#38C7BD",
+      secondary: "#122339",
+      accent: "#4F89C5",
+      muted: "#122339",
+      border: "#1D3852",
       gradient: "linear-gradient(135deg, #38C7BD 0%, #4F89C5 100%)",
-      accent: "#4F89C5", // medium blue
-      muted: "#122339", // slightly lighter blue
-      border: "#1D3852", // medium blue
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #4F89C5 70%, transparent), #0A1A2F, color-mix(in srgb, #122339 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #0A1A2F 0%, color-mix(in srgb, #4F89C5 15%, #0A1A2F) 100%)",
     },
   },
-
   {
     id: "monochrome",
     name: "Monochrome",
     type: "dark",
     colors: {
-      background: "#131B29", // deep blue-gray
-      foreground: "#F7F9FB", // off-white
-      primary: "#F7F9FB", // off-white
-      secondary: "#283547", // medium blue-gray
+      background: "#131B29",
+      foreground: "#F7F9FB",
+      primary: "#F7F9FB",
+      secondary: "#283547",
+      accent: "#283547",
+      muted: "#283547",
+      border: "#48566A",
       gradient: "linear-gradient(135deg, #F7F9FB 0%, #283547 100%)",
-      accent: "#283547", // medium blue-gray
-      muted: "#283547", // medium blue-gray
-      border: "#48566A", // lighter blue-gray
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #283547 70%, transparent), #131B29, color-mix(in srgb, #283547 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #131B29 0%, color-mix(in srgb, #283547 15%, #131B29) 100%)",
     },
   },
   {
@@ -222,14 +244,16 @@ export const defaultThemes: Theme[] = [
     name: "Midnight",
     type: "dark",
     colors: {
-      background: "#16181C", // hsl(220 13% 10%)",
-      foreground: "#EFF1F4", // hsl(220 20% 95%)",
-      primary: "#5181E0", // hsl(220 70% 60%)",
-      secondary: "#282C33", // hsl(220 12% 18%)",
+      background: "#16181C",
+      foreground: "#EFF1F4",
+      primary: "#5181E0",
+      secondary: "#282C33",
+      accent: "#383D47",
+      muted: "#282C33",
+      border: "#383D47",
       gradient: "linear-gradient(135deg, #5181E0 0%, #383D47 100%)",
-      accent: "#383D47", // hsl(220 12% 25%)",
-      muted: "#282C33", // hsl(220 12% 18%)",
-      border: "#383D47", // hsl(220 12% 25%)",
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #383D47 70%, transparent), #16181C, color-mix(in srgb, #282C33 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #16181C 0%, color-mix(in srgb, #383D47 15%, #16181C) 100%)",
     },
   },
   {
@@ -237,14 +261,16 @@ export const defaultThemes: Theme[] = [
     name: "Crimson",
     type: "dark",
     colors: {
-      background: "#1D1518", // hsl(340 15% 10%)",
-      foreground: "#F6F2F4", // hsl(340 20% 96%)",
-      primary: "#D22C63", // hsl(340 65% 50%)",
-      secondary: "#32292C", // hsl(340 10% 18%)",
+      background: "#1D1518",
+      foreground: "#F6F2F4",
+      primary: "#D22C63",
+      secondary: "#32292C",
+      accent: "#46393D",
+      muted: "#32292C",
+      border: "#46393D",
       gradient: "linear-gradient(135deg, #D22C63 0%, #46393D 100%)",
-      accent: "#46393D", // hsl(340 10% 25%)",
-      muted: "#32292C", // hsl(340 10% 18%)",
-      border: "#46393D", // hsl(340 10% 25%)",
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #46393D 70%, transparent), #1D1518, color-mix(in srgb, #32292C 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #1D1518 0%, color-mix(in srgb, #46393D 15%, #1D1518) 100%)",
     },
   },
   {
@@ -252,14 +278,16 @@ export const defaultThemes: Theme[] = [
     name: "Cyberpunk",
     type: "dark",
     colors: {
-      background: "#131117", // hsl(260 15% 8%)",
-      foreground: "#F1EFF4", // hsl(260 20% 95%)",
-      primary: "#CF47EA", // hsl(290 80% 60%)",
-      secondary: "#27232D", // hsl(260 12% 16%)",
+      background: "#131117",
+      foreground: "#F1EFF4",
+      primary: "#CF47EA",
+      secondary: "#27232D",
+      accent: "#16CEAF",
+      muted: "#27232D",
+      border: "#3D3847",
       gradient: "linear-gradient(135deg, #CF47EA 0%, #16CEAF 100%)",
-      accent: "#16CEAF", // hsl(170 80% 45%)",
-      muted: "#27232D", // hsl(260 12% 16%)",
-      border: "#3D3847", // hsl(260 12% 25%)",
+      ambientGradient: "linear-gradient(135deg, color-mix(in srgb, #16CEAF 70%, transparent), #131117, color-mix(in srgb, #27232D 50%, transparent))",
+      cardGradient: "linear-gradient(180deg, #131117 0%, color-mix(in srgb, #16CEAF 15%, #131117) 100%)",
     },
   },
 ];

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -42,6 +42,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#0F1729",
       primary: "#1E293B",
       secondary: "#F1F5F9",
+      gradient: "linear-gradient(135deg, #1E293B 0%, #F1F5F9 100%)",
       accent: "#F1F5F9",
       muted: "#F1F5F9",
       border: "#E2E8F0",
@@ -56,6 +57,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#FAFAFA", // hsl(0 0% 98%)
       primary: "#FAFAFA", // hsl(0 0% 98%)
       secondary: "#1E1E2A", // hsl(240 3.7% 15.9%)
+      gradient: "linear-gradient(135deg, #FAFAFA 0%, #1E1E2A 100%)",
       accent: "#1E1E2A", // hsl(240 3.7% 15.9%)
       muted: "#1E1E2A", // hsl(240 3.7% 15.9%)
       border: "#1E1E2A", // hsl(240 3.7% 15.9%)
@@ -70,6 +72,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#FAFAFA", // hsl(0 0% 98%)
       primary: "#FAFAFA", // hsl(0 0% 98%)
       secondary: "#1E1E2A", // hsl(240 3.7% 15.9%)
+      gradient: "linear-gradient(135deg, #FAFAFA 0%, #1E1E2A 100%)",
       accent: "#1E1E2A", // hsl(240 3.7% 15.9%)
       muted: "#1E1E2A", // hsl(240 3.7% 15.9%)
       border: "#1E1E2A", // hsl(240 3.7% 15.9%)
@@ -84,6 +87,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#291839", // hsl(272 40% 16%)",
       primary: "#8432CC", // hsl(272 60% 50%)",
       secondary: "#E7DBEF", // hsl(275 40% 90%)",
+      gradient: "linear-gradient(135deg, #8432CC 0%, #E1D7E9 100%)",
       accent: "#E1D7E9", // hsl(272 30% 88%)",
       muted: "#E7DBEF", // hsl(275 40% 90%)",
       border: "#E1D7E9", // hsl(272 30% 88%)",
@@ -98,6 +102,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#311A22", // hsl(340 30% 15%)",
       primary: "#D64173", // hsl(340 65% 55%)",
       secondary: "#EFDBE2", // hsl(340 40% 90%)",
+      gradient: "linear-gradient(135deg, #D64173 0%, #E4CDD4 100%)",
       accent: "#E4CDD4", // hsl(340 30% 85%)",
       muted: "#E8C9D3", // hsl(340 40% 85%)",
       border: "#E4CDD4", // hsl(340 30% 85%)",
@@ -112,6 +117,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#0E1629", // hsl(222 47% 11%)",
       primary: "#0065CC", // hsl(210 100% 40%)",
       secondary: "#DBE5EF", // hsl(210 40% 90%)",
+      gradient: "linear-gradient(135deg, #0065CC 0%, #CDD8E4 100%)",
       accent: "#CDD8E4", // hsl(210 30% 85%)",
       muted: "#CDD8E4", // hsl(210 30% 85%)",
       border: "#CDD8E4", // hsl(210 30% 85%)",
@@ -126,6 +132,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#1F3F1F", // hsl(145 50% 10%)
       primary: "#2F8F2F", // hsl(145 60% 35%)
       secondary: "#D5EAD5", // hsl(145 30% 85%)
+      gradient: "linear-gradient(135deg, #2F8F2F 0%, #AAD4AA 100%)",
       accent: "#AAD4AA", // hsl(145 40% 75%)
       muted: "#C2D9C2", // hsl(145 20% 80%)
       border: "#A8C8A8", // hsl(145 30% 75%)
@@ -140,6 +147,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#352116", // hsl(20 40% 15%)",
       primary: "#F35524", // hsl(14 90% 55%)",
       secondary: "#F9E1D1", // hsl(24 80% 90%)",
+      gradient: "linear-gradient(135deg, #F35524 0%, #EAC5AD 100%)",
       accent: "#EAC5AD", // hsl(24 60% 80%)",
       muted: "#E8D5C9", // hsl(24 40% 85%)",
       border: "#DBC8BC", // hsl(24 30% 80%)",
@@ -154,6 +162,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#3A2E21", // deep desert brown
       primary: "#D2A052", // golden sand
       secondary: "#F2E8D9", // light sand
+      gradient: "linear-gradient(135deg, #D2A052 0%, #E1CEB3 100%)",
       accent: "#E1CEB3", // medium sand/khaki
       muted: "#F2E8D9", // light sand
       border: "#E1CEB3", // medium sand/khaki
@@ -170,6 +179,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#F2EBFF", // light purple-white
       primary: "#B87AFF", // bright purple
       secondary: "#241B2F", // slightly lighter purple-black
+      gradient: "linear-gradient(135deg, #B87AFF 0%, #6C40B5 100%)",
       accent: "#6C40B5", // medium purple
       muted: "#241B2F", // slightly lighter purple-black
       border: "#352644", // medium purple
@@ -185,6 +195,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#E6F4F1", // seafoam white
       primary: "#38C7BD", // teal
       secondary: "#122339", // slightly lighter blue
+      gradient: "linear-gradient(135deg, #38C7BD 0%, #4F89C5 100%)",
       accent: "#4F89C5", // medium blue
       muted: "#122339", // slightly lighter blue
       border: "#1D3852", // medium blue
@@ -200,6 +211,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#F7F9FB", // off-white
       primary: "#F7F9FB", // off-white
       secondary: "#283547", // medium blue-gray
+      gradient: "linear-gradient(135deg, #F7F9FB 0%, #283547 100%)",
       accent: "#283547", // medium blue-gray
       muted: "#283547", // medium blue-gray
       border: "#48566A", // lighter blue-gray
@@ -214,6 +226,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#EFF1F4", // hsl(220 20% 95%)",
       primary: "#5181E0", // hsl(220 70% 60%)",
       secondary: "#282C33", // hsl(220 12% 18%)",
+      gradient: "linear-gradient(135deg, #5181E0 0%, #383D47 100%)",
       accent: "#383D47", // hsl(220 12% 25%)",
       muted: "#282C33", // hsl(220 12% 18%)",
       border: "#383D47", // hsl(220 12% 25%)",
@@ -228,6 +241,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#F6F2F4", // hsl(340 20% 96%)",
       primary: "#D22C63", // hsl(340 65% 50%)",
       secondary: "#32292C", // hsl(340 10% 18%)",
+      gradient: "linear-gradient(135deg, #D22C63 0%, #46393D 100%)",
       accent: "#46393D", // hsl(340 10% 25%)",
       muted: "#32292C", // hsl(340 10% 18%)",
       border: "#46393D", // hsl(340 10% 25%)",
@@ -242,6 +256,7 @@ export const defaultThemes: Theme[] = [
       foreground: "#F1EFF4", // hsl(260 20% 95%)",
       primary: "#CF47EA", // hsl(290 80% 60%)",
       secondary: "#27232D", // hsl(260 12% 16%)",
+      gradient: "linear-gradient(135deg, #CF47EA 0%, #16CEAF 100%)",
       accent: "#16CEAF", // hsl(170 80% 45%)",
       muted: "#27232D", // hsl(260 12% 16%)",
       border: "#3D3847", // hsl(260 12% 25%)",

--- a/lib/services/itineraries.ts
+++ b/lib/services/itineraries.ts
@@ -14,7 +14,9 @@ import {
   ItineraryDayType,
   createItinerarySchema,
   updateItinerarySchema,
+  Itinerary,
 } from "@/types/itineraries";
+import { PublicShare } from "./publicShares";
 
 // **Collection Reference**
 const getItineraryCollection = (userId: string) =>
@@ -196,7 +198,7 @@ export interface TodayItineraryTask {
 
 /** Fetch all itinerary tasks scheduled for today across active itineraries */
 export const getTodayItineraryTasks = async (
-  userId: string
+  userId: string,
 ): Promise<TodayItineraryTask[]> => {
   const itineraries = await getItineraries(userId);
   if (!itineraries || itineraries.length === 0) return [];
@@ -220,7 +222,9 @@ export const getTodayItineraryTasks = async (
       const diffTime = today.getTime() - start.getTime();
       const dayIndex = Math.floor(diffTime / (1000 * 60 * 60 * 24));
 
-      const dayObj = itinerary.days[dayIndex] || itinerary.days.find((d, idx) => idx === dayIndex);
+      const dayObj =
+        itinerary.days[dayIndex] ||
+        itinerary.days.find((d, idx) => idx === dayIndex);
 
       if (dayObj && dayObj.tasks) {
         for (const task of dayObj.tasks) {
@@ -240,10 +244,53 @@ export const getTodayItineraryTasks = async (
 };
 
 /** Import / Duplicate a publicly shared itinerary into user's profile */
-export const importPublicItinerary = async (
-  userId: string,
-  share: any
-) => {
+export const duplicatePublicItineraryData = (share: PublicShare) => {
+  if (share.type !== "itinerary") {
+    throw new Error("Only itineraries can be imported to planner");
+  }
+
+  // Calculate default start date as today and end date based on totalDays
+  const startDateObj = new Date();
+  const totalDays = share.totalDays || share.days?.length || 1;
+  const endDateObj = new Date(startDateObj);
+  endDateObj.setDate(endDateObj.getDate() + (totalDays - 1));
+
+  const startDateStr = startDateObj.toISOString().split("T")[0];
+  const endDateStr = endDateObj.toISOString().split("T")[0];
+
+  // Reset task completed state to false for all tasks in imported days
+  const cleanDays = (share.days || []).map((day: any, idx: number) => ({
+    id: `day_${Date.now()}_${idx}`,
+    title: day.title || `Day ${idx + 1}`,
+    budget: typeof day.budget === "number" ? day.budget : 0,
+    tasks: (day.tasks || []).map((task: any, tIdx: number) => ({
+      id: `task_${Date.now()}_${tIdx}`,
+      title: task.title || "Activity",
+      time: task.time || "",
+      completed: false, // Reset completed status for importer!
+    })),
+  }));
+
+  const itineraryData: ItineraryCreate = {
+    title: `${share.title}`,
+    destination: share.destination || "",
+    coverImage: share.coverImage || "",
+    startDate: startDateStr,
+    endDate: endDateStr,
+    totalDays,
+    budget: share.budget || 0,
+    actualCost: 0,
+    days: cleanDays,
+    notes: share.content || "",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  return itineraryData;
+};
+
+/** Import / Duplicate a publicly shared itinerary into user's profile */
+export const importPublicItinerary = async (userId: string, share: any) => {
   if (share.type !== "itinerary") {
     throw new Error("Only itineraries can be imported to planner");
   }
@@ -287,4 +334,3 @@ export const importPublicItinerary = async (
 
   return await addItinerary(userId, itineraryData);
 };
-

--- a/lib/services/publicShares.ts
+++ b/lib/services/publicShares.ts
@@ -1,5 +1,16 @@
 import { db } from "./firebase/db";
-import { doc, getDoc, setDoc, deleteDoc, collection, query, where, orderBy, limit, getDocs } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  setDoc,
+  deleteDoc,
+  collection,
+  query,
+  where,
+  orderBy,
+  limit,
+  getDocs,
+} from "firebase/firestore";
 
 export interface PublicShare {
   id: string;
@@ -14,6 +25,7 @@ export interface PublicShare {
   endDate?: string;
   totalDays?: number;
   days?: any[];
+  budget?: number;
   authorName?: string;
   authorPhoto?: string;
   theme?: string;
@@ -24,14 +36,17 @@ export interface PublicShare {
 const PUBLIC_SHARES_COLLECTION = "publicShares";
 
 /** Generate a deterministic share ID for an item */
-export function getShareId(type: "journal" | "itinerary", itemId: string): string {
+export function getShareId(
+  type: "journal" | "itinerary",
+  itemId: string,
+): string {
   return `pub_${type}_${itemId}`;
 }
 
 /** Create or update a public share document */
 export async function createPublicShare(
   userId: string,
-  shareData: Omit<PublicShare, "userId" | "createdAt" | "updatedAt">
+  shareData: Omit<PublicShare, "userId" | "createdAt" | "updatedAt">,
 ): Promise<PublicShare> {
   const shareId = shareData.id || getShareId(shareData.type, shareData.id);
   const docRef = doc(db, PUBLIC_SHARES_COLLECTION, shareId);
@@ -46,7 +61,7 @@ export async function createPublicShare(
 
   // Strip undefined values to satisfy Firestore SDK constraints
   const cleanPayload = Object.fromEntries(
-    Object.entries(rawPayload).filter(([_, value]) => value !== undefined)
+    Object.entries(rawPayload).filter(([_, value]) => value !== undefined),
   ) as PublicShare;
 
   await setDoc(docRef, cleanPayload, { merge: true });
@@ -54,7 +69,9 @@ export async function createPublicShare(
 }
 
 /** Fetch a public share document by shareId (unauthenticated) */
-export async function getPublicShare(shareId: string): Promise<PublicShare | null> {
+export async function getPublicShare(
+  shareId: string,
+): Promise<PublicShare | null> {
   try {
     const docRef = doc(db, PUBLIC_SHARES_COLLECTION, shareId);
     const snapshot = await getDoc(docRef);
@@ -76,7 +93,7 @@ export async function deletePublicShare(shareId: string): Promise<void> {
 /** Fetch all publicly shared items for the Explore Gallery */
 export async function getPublicShares(
   typeFilter?: "journal" | "itinerary" | "all",
-  maxResults = 50
+  maxResults = 50,
 ): Promise<PublicShare[]> {
   try {
     const colRef = collection(db, PUBLIC_SHARES_COLLECTION);
@@ -87,7 +104,7 @@ export async function getPublicShares(
         colRef,
         where("type", "==", typeFilter),
         orderBy("createdAt", "desc"),
-        limit(maxResults)
+        limit(maxResults),
       );
     } else {
       q = query(colRef, orderBy("createdAt", "desc"), limit(maxResults));
@@ -102,13 +119,15 @@ export async function getPublicShares(
 }
 
 /** Fetch all public shares created by a specific user */
-export async function getUserPublicShares(userId: string): Promise<PublicShare[]> {
+export async function getUserPublicShares(
+  userId: string,
+): Promise<PublicShare[]> {
   try {
     const colRef = collection(db, PUBLIC_SHARES_COLLECTION);
     const q = query(
       colRef,
       where("userId", "==", userId),
-      orderBy("createdAt", "desc")
+      orderBy("createdAt", "desc"),
     );
     const snapshot = await getDocs(q);
     return snapshot.docs.map((doc) => doc.data() as PublicShare);

--- a/lib/utils/colors.ts
+++ b/lib/utils/colors.ts
@@ -44,8 +44,8 @@ export function hexToHSL(hex: string): string {
 
   return `${h} ${s}% ${l}%`;
 }
-// Invert a color for contrast
 
+// Invert a color for contrast
 export function invertColor(hex: string): string {
   hex = hex.replace("#", "");
   const r = parseInt(hex.substring(0, 2), 16);
@@ -128,6 +128,11 @@ export const addCustomCssVariables = (themeObj: Theme) => {
         )}), color-mix(in srgb, hsl(${hexToHSL(
           themeObj.colors.secondary
         )}) 50%, transparent));
+        --card-gradient: linear-gradient(180deg, hsl(${hexToHSL(
+          themeObj.colors.background
+        )}) 0%, color-mix(in srgb, hsl(${hexToHSL(
+          themeObj.colors.accent
+        )}) 15%, hsl(${hexToHSL(themeObj.colors.background)})) 100%);
       }
     `;
   styleEl.textContent = cssVariables;

--- a/lib/utils/colors.ts
+++ b/lib/utils/colors.ts
@@ -115,6 +115,19 @@ export const addCustomCssVariables = (themeObj: Theme) => {
         --popover: hsl(${hexToHSL(themeObj.colors.background)});
         --popover-foreground: hsl(${hexToHSL(themeObj.colors.foreground)});
         --ring: hsl(${hexToHSL(themeObj.colors.primary)});
+        --primary-gradient: ${
+          themeObj.colors.gradient ||
+          `linear-gradient(135deg, hsl(${hexToHSL(
+            themeObj.colors.primary
+          )}), hsl(${hexToHSL(themeObj.colors.accent)}))`
+        };
+        --ambient-gradient: linear-gradient(135deg, color-mix(in srgb, hsl(${hexToHSL(
+          themeObj.colors.accent
+        )}) 70%, transparent), hsl(${hexToHSL(
+          themeObj.colors.background
+        )}), color-mix(in srgb, hsl(${hexToHSL(
+          themeObj.colors.secondary
+        )}) 50%, transparent));
       }
     `;
   styleEl.textContent = cssVariables;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "next-cloudinary": "^6.16.0",
     "next-themes": "^0.4.6",
     "nprogress": "^0.2.0",
+    "radix-ui": "^1.6.5",
     "react": "19.1.0",
     "react-day-picker": "8.10.1",
     "react-dom": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapjot",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3030",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
+      radix-ui:
+        specifier: ^1.6.5
+        version: 1.6.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1625,11 +1628,43 @@ packages:
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
+  '@radix-ui/number@1.1.3':
+    resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
+
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.7':
+    resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
+
+  '@radix-ui/react-accessible-icon@1.1.13':
+    resolution: {integrity: sha512-2/0RrtTngKZVkOFYDlvhe6JIsUravRnYGwH1iJ+qt+wPu8/fPu3HTLRkQptyIkpLovAy8qvHHJs9cvYJ3Uyqqg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-accordion@1.2.10':
     resolution: {integrity: sha512-x+URzV1siKmeXPSUIQ22L81qp2eOhjpy3tgteF+zOr4d1u0qJnFuyBF4MoQRhmKP6ivDxlvDAvqaF77gh7DOIw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.18':
+    resolution: {integrity: sha512-CGuUFvhjScXBF/bhjaU9xlgai2ikYqJRazXhMzngoUaZI7QaxAw24Ae3S/pR0b69p8GqW6i+CKJmx9JPNnZ4QQ==}
     peerDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5
@@ -1654,8 +1689,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-alert-dialog@1.1.21':
+    resolution: {integrity: sha512-VbSR148lNkE8JdWnOsYX72YdivmCAtcrot1dl8UmT0ZZRKNR3hHJUpQxJOw7jWlY/JFemn4oaDXxCxpD594B7Q==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.13':
+    resolution: {integrity: sha512-0Q310knIY0K+mkmncU9FxLggfW7V49Ok2oY+iu27KkERTsQXxYCIC8XW5QoK4w7Jp1z00vT5xj3oxTcn7QlcTg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.6':
     resolution: {integrity: sha512-2JMfHJf/eVnwq+2dewT3C0acmCWD3XiVA1Da+jTDqo342UlU13WvXtqHhG+yJw5JeQmu4ue2eMy6gcEArLBlcw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.13':
+    resolution: {integrity: sha512-dD/EvbOiLskcdBKgNAeUmbTBCJfdCGp85fpFe3lmziE4ASbXuFERQCAB3sR41yvM+P711kJsTBNL9piP60urbA==}
     peerDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5
@@ -1680,6 +1754,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.2.4':
+    resolution: {integrity: sha512-u4Sz6ajq2WobGMqbsNXnFI/3JP/o7TUBkEmQ4BRUYofPDQawdO3WWYy5907c9VgOFX+ETjKI3VxnnrKYAF7Pmg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.1':
     resolution: {integrity: sha512-xTaLKAO+XXMPK/BpVTSaAAhlefmvMSACjIhK9mGsImvX2ljcTDm8VGR1CuS1uYcNdR5J+oiOhoJZc5un6bh3VQ==}
     peerDependencies:
@@ -1693,8 +1780,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-checkbox@1.3.9':
+    resolution: {integrity: sha512-YPXZlqjrKVqKtVD2F828CApHwu+PEu30i7x0Y9gg6SbQ3fJbcaQlDkGPT0gW6HjxoCjAEt8uJ494F1S61KpIjQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collapsible@1.1.10':
     resolution: {integrity: sha512-O2mcG3gZNkJ/Ena34HurA3llPOEA/M4dJtIRMa6y/cknRDC8XY5UZBInKTsUwW5cUue9A4k0wi1XU5fKBzKe1w==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.18':
+    resolution: {integrity: sha512-aNMp8humfYzWERz5gxGb/eLNkB0ZthypLbNlNolzdgzFTeN78e/rnn9rxCdOaSsg/zClTOJ/OkjXYx9PUEPATw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.13':
+    resolution: {integrity: sha512-Q8xYqNRFObXPmi45bFSkGdM2JA5hjBeYGFqzg6lZR3wp6b+cciraVq8DdneTabtws+uOYqjmsvmKOufk/M9Cyg==}
     peerDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5
@@ -1728,8 +1854,39 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.4':
+    resolution: {integrity: sha512-pWJo6lQAfR6uy1n7ii7PaCc9dLPwTXDYbQpORZU5B548Aqvl2pP1SM1vJGKyxIFqZMHRopRO4CQYX2iXAIB5jA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.3.5':
+    resolution: {integrity: sha512-wbvSjqc7r0xKmfhrMCiCPxSTv/aSHU0cCAy0tELthJbaIzT7dkAcevKuoGKbDLiPG2VePgMVqLi2sWb6tDnzvQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.1':
+    resolution: {integrity: sha512-EraVbFjiIjibpLr6EjvEDmSCYJU2SlKDMiO+qEK/D9GOWnQoAQlpQo2occGYC1UM9MBeEx5Bek3UtW/Qi57vAg==}
     peerDependencies:
       '@types/react': 19.1.4
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1750,6 +1907,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.21':
+    resolution: {integrity: sha512-h+7qMDDmZJ8qTSPrwNyKb/PACY0ehtN8QOBlCz+C2C1jgehKekdhmHddG9YQk8BF/sHJqglPjte+jA1Jrp9HcA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -1757,6 +1927,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.3':
+    resolution: {integrity: sha512-OdgAA/xb6WOQMKNn0mtbYoruMG6YMaBOnq+evWxSpMmiEMBdeFZawnIWRfPPeVXCRm+0lnN8jpJLjhD7/UIxWw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.17':
+    resolution: {integrity: sha512-QAXwa38pG0xNAYh1pjdSaf86NrkqsMoDNmget/Y7X8O8E/C3Iqlj9GAPE4DfX9BPLXc7WH2TWSzMRnIoCdcjzQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.9':
@@ -1785,6 +1977,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.22':
+    resolution: {integrity: sha512-wZRLTjZaJf1HTxx0YepFKZUuo+SZMi+Cr4kJ2fuA5FxDSUE0vHDTscahUaU+jfz6LFk4OuguwqJs5K0JsIsIBA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.2':
     resolution: {integrity: sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==}
     peerDependencies:
@@ -1794,8 +1999,56 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.1.5':
+    resolution: {integrity: sha512-UQvlB7L/BYh3P8MLvwZnQkH521EDos40Rwnbt5+Qpg4Vbk0z3xJjRUmR6+aka4aT1IQQXFdO5bNPoE7cvFl5xQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.14':
+    resolution: {integrity: sha512-/x4htnJfmW53MplkrePaDpf1o/rN1C++g88WpVobULXbSyC19NtLkXmewuJ/HCaceSmfKDNL5gOXcBGnuAvnvQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-scope@1.1.6':
     resolution: {integrity: sha512-r9zpYNUQY+2jWHWZGyddQLL9YHkM/XvSFHVcWs7bdVuxMAnCwTAuy6Pf47Z4nw7dYcUou1vg/VgjjrrH03VeBw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-form@0.1.14':
+    resolution: {integrity: sha512-ZCuPb54PQ3ZQEdQ6G1PrMBfXXzAyaVoCI9Fl+bWOwYZKTOcFjPHL7JQ3tCb6CX6Ut81GZLWKgIpV6OS3n5z5Ig==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.21':
+    resolution: {integrity: sha512-ByFLyi+kdTGkObxIt5wKB3Ru3rtJRuYUqPEtqiv1HNYqutqbn1wDuNmVzI6iwus9qfY3vwpNgvx/UVZUGTWC1A==}
     peerDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5
@@ -1814,6 +2067,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.3':
+    resolution: {integrity: sha512-f/Wxm0ctyMymUJK0fqTSQlm85rbzdAkoNbPXJQ5+6caowVO8Yx+NWGjGz/oGhs/D+WIbbQpOrU0hU2Li2/42xQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.13':
+    resolution: {integrity: sha512-kj7BXyM4uG0dyeoEdVmPQAOFN291+iJOtiGTvkXe1ijJWLQbAHpFNkopvqquaMVn+zjqTZRhnefESAinMErHKg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-label@2.1.6':
@@ -1842,6 +2117,71 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-menu@2.1.22':
+    resolution: {integrity: sha512-xCFrVLttGDPwMjIPI6GS+tm3IGUNKsPXffrJQIPpQJuE9Qy1bU9GNUCkwranU/pEqyBlwMxcBIK/FUJFAZ9SqQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.22':
+    resolution: {integrity: sha512-jDkcZXd5rN4b/S9nnEv9KZajaQ7+RO98OCWqAxrULTJtkSvODlNOO+EIxNG/d4QIF6QOqK5ZZrTF9MYl6eQdiQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.20':
+    resolution: {integrity: sha512-in/exCQPatmmBmQZrtQkK4UrysEp8VGEuw5o8Bx3ozxbfg7DBb4H5j3DgxGz4N59J02NRVzhsWFtujZgy5ue3w==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.14':
+    resolution: {integrity: sha512-F3vMSK+d+huI3a4Zm6j2hUsS+/gByVbsechJwp/ZCZBCrusXHvBeZZz9aMqXqqYNYu23mtvVMt6AeHDds8EU7w==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.9':
+    resolution: {integrity: sha512-JFkmnwZFD357odQkpzfxz++bpohQpaGCT/4PK6oRd4R/Rxzg02uFDucFzZDOTIOz6vWSluIlz91zelleg9BheA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popover@1.1.13':
     resolution: {integrity: sha512-84uqQV3omKDR076izYgcha6gdpN8m3z6w/AeJ83MSBJYVG/AbOHdLjAgsPZkeC/kt+k64moXFCnio8BbqXszlw==}
     peerDependencies:
@@ -1855,8 +2195,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popover@1.1.21':
+    resolution: {integrity: sha512-+AJ7P5oRcFqFtv7MaCD8fOuK3l5qQBAMdWEOnUOYd3JfHOeIUe7TnHHSSP15CtWwH4KrotyDCTzodOIoONh8vw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popper@1.2.6':
     resolution: {integrity: sha512-7iqXaOWIjDBfIG7aq8CUEeCSsQMLFdn7VEE8TaFz704DtEzpPHR7w/uuzRflvKgltqSAImgcmxQ7fFX3X7wasg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.5':
+    resolution: {integrity: sha512-6hLng2Rs45IZcvZ31BNvMeaFEMMEbtsog4xPcb8LZrGfyoV9fdAXqB9UKhLpTHtL0+E2DhSr6VW54Tehd6ksAQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.15':
+    resolution: {integrity: sha512-kAfBVJUKNNKZuyGQXXG6rKolAV2KAmxxVkPXJgoq9dEFTl39286RufHQFNTL8rzha4vP8159BJ6hMGpB+bqv7A==}
     peerDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5
@@ -1894,8 +2273,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.9':
+    resolution: {integrity: sha512-LTi1v05bprIb8/GSY/GWusI0jfsYjQ3CD3Nin8o7jVxnpHzVQfzjOQJoJTQkE9bdmOnsS7SFdhkXiBv8PrYnxw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.2':
     resolution: {integrity: sha512-uHa+l/lKfxuDD2zjN/0peM/RhhSmRjr5YWdk/37EnSv1nJ88uvG85DPexSm8HdFQROd2VdERJ6ynXbkCFi+APw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.8':
+    resolution: {integrity: sha512-DOlK1BdcIeYYUcFkSYFka4v1h95XTov93b0jCgW1EEiZuIhdwHY2NlE1teLIh+p0uBsuZI5A+voay+iVWpprfA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.14':
+    resolution: {integrity: sha512-lq5VXWp/t/b8MaqbRMAItXICc/jwhzJt0ZZ+au/CBtTYkX9EfAsSyGQL5brUVBgf9tUTKCoJEZlDl+uJF/08xQ==}
     peerDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5
@@ -1933,6 +2351,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-radio-group@1.4.5':
+    resolution: {integrity: sha512-BM1xQgw1gpgPSw05U4hJCMDX9GmAS6b6vKZANuNQZo0vf/ah7NZDAnjLd4tPg3z2vMvlI0CV+B2CFM9Z19oQDA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.17':
+    resolution: {integrity: sha512-YdJmjETw7Py+4Nziv71jgZ6fH7xQgB5p+pQ5rV8Iufyrm0RHSijec/UV1zPfQoK/YcfzB9nOl/2bi1zf1SjRMQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.9':
     resolution: {integrity: sha512-ZzrIFnMYHHCNqSNCsuN6l7wlewBEq0O0BCSBkabJMFXVO51LRUTq71gLP1UxFvmrXElqmPjA5VX7IqC9VpazAQ==}
     peerDependencies:
@@ -1946,8 +2390,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-scroll-area@1.2.16':
+    resolution: {integrity: sha512-kEcmCenIJ+W5xlCv1u9VKDdPmzzGyfrJwEneY+02GH+lJRXrGpkiTkyjrfkspuRw6DXt4uduwT5c4xD8HTv27Q==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.2.4':
     resolution: {integrity: sha512-/OOm58Gil4Ev5zT8LyVzqfBcij4dTHYdeyuF5lMHZ2bIp0Lk9oETocYiJ5QC0dHekEQnK6L/FNJCceeb4AkZ6Q==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.3.5':
+    resolution: {integrity: sha512-6CQx0xtdarAkSCsqgLJaz+coYQaru7rt8K6gMItR2rA+WP8/Ig6kRAzP6Zw88RccG98IZnszqJlJx9hejYOL3A==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.13':
+    resolution: {integrity: sha512-wbagLhy4grekqiT6hU0WNP09FpmemTXbNWg4QEawaw9dix7hRIcrmDNnLDasOsKVLtArEznhgZKe5Gm4U6oPXQ==}
     peerDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5
@@ -1985,8 +2468,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-slider@1.4.5':
+    resolution: {integrity: sha512-7E8C13SdQKQxYganILiVZGEwM0NSbfbFcnNJ93kP++wD2pMT1SMsG3c04PFUlbPpaSXgicYgPeBndgJTvV3NKg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.2':
     resolution: {integrity: sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.1':
+    resolution: {integrity: sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw==}
     peerDependencies:
       '@types/react': 19.1.4
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2007,8 +2512,99 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-switch@1.3.5':
+    resolution: {integrity: sha512-e1YrvGvEjIqDhqKjQ4Q+IDkMfiY30u3FPz9CZXZMlQ8mU3kZ2PdeBM8Gssc48CDopPizNorKumGhjySBfO7BDQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tabs@1.1.11':
     resolution: {integrity: sha512-4FiKSVoXqPP/KfzlB7lwwqoFV6EPwkrrqGp9cUYXjwDYHhvpnqq79P+EPHKcdoTE7Rl8w/+6s9rTlsfXHES9GA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.19':
+    resolution: {integrity: sha512-4wbGf98pX2ZwYqHMVB/dakeMPyH4xSJ9MSDaCCWXlIpYt0VYY6mtZxKSTiGS/F3tk0yrEYmXE1V8uwG7TxDCcQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.21':
+    resolution: {integrity: sha512-/o8uHzH2z6ZM59Dt1UPFj8aYJ0DjPu0EuQXQ7uuYJTQLH5mNqxa1KuBfbpnklgXOOjyAtTp/tll0Nm+Nkz+bEg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.17':
+    resolution: {integrity: sha512-KKsrxb1cZREc2RI5DOGwlUSpaPW40xIaK1/DXXqYDb7slRE8pkRa+iF2aFbYiuMJ+aNWpCSChiN5gFe3bVveaQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.16':
+    resolution: {integrity: sha512-pp4TLY3N4osN9IB4TLEaaZRGooBmCi/XJD65gSCs5tvsKofM9WgiBToNtGrmR0k3sG4jFj4Nw4utsIvQraWA9g==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.17':
+    resolution: {integrity: sha512-MjorZ0XQiWfCrrpStNXw/hX0HnG7VEzCgcSV226Ox8/WzS5yq0SiMhsLFE3LlXhdghlakFRFdE6eegtmUQW7Mg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.14':
+    resolution: {integrity: sha512-C/JxCKJJac+wtHPW1yFBSN8Ssuaufy2jYQMgyiJYyW4Fw0WJfDWXQDAly1qsbd1YDznH+sYitaljhf8igPCvmA==}
     peerDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5
@@ -2042,8 +2638,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.3':
+    resolution: {integrity: sha512-AUS7HoBBAncIsGMLNG+CcpLuJ+JIBbZzmyM8Qdb1eIThX0AlhSSC6wn40xfBlPE+ypx/vSSiRWnklUAjy3U3UA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.5':
+    resolution: {integrity: sha512-UB1dXpxvHjR48poyKdKdTm7jT0kp3elkUKdKQiOkirlbYumqXinSJtrjDsr9maXNPvL12bKI4CDSmydms/9Aeg==}
     peerDependencies:
       '@types/react': 19.1.4
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2060,8 +2674,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-effect-event@0.0.4':
+    resolution: {integrity: sha512-XYcfa6wlXDCwQtePuEiPmXLSAhGL4DWtedSyRgGbG3y10mw+OnrLp6SyeY1gJFMiYF0Dx0nMAX9InylKbLEFQQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.4':
+    resolution: {integrity: sha512-4MSb5SPbMH02uUn19tLkO5Bav66ZQg/zFbedo7FWLWGFg9r8Z9xSog7QGnq9ZceurzBVIAIwgzANg6ExWc8HkQ==}
     peerDependencies:
       '@types/react': 19.1.4
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2078,8 +2710,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-is-hydrated@0.1.2':
+    resolution: {integrity: sha512-2+gAVu9uaSLbopCTvvuWX9MIgEOlyqXC1Ok+KLCO7cZPSHLENs7dL0KbFQUGFIcFKmDW/bmaQRJtd8E3cnMRUw==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.3':
+    resolution: {integrity: sha512-rDiah9wvtqihWtWz02XreeRKIxt2EJF8y5D9rtY9l5A2zxePAtcPiOMpDugNRw5bFHz+1/8viVoc7ZVKiJknCw==}
     peerDependencies:
       '@types/react': 19.1.4
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2096,6 +2746,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-previous@1.1.3':
+    resolution: {integrity: sha512-kbefNKla5AGhgvMqrg/qS7mYVLXTEHQLqoFIS03nKN2dAfQQ5PK5Tp+2LxS7BV6a6l4HHv4jTg6rtV2Uajwe2w==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.1':
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
@@ -2105,8 +2764,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.3':
+    resolution: {integrity: sha512-W0GSYZFKEfi6raMiMEfJSngvVbFDIyxtW5JuVg5NoQBY59l0dVQVGLbhog/tOdwq0qtZ+TXuX1ikSNan4/IZXA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.3':
+    resolution: {integrity: sha512-jJq6tQQLvO/z4uWbztjwPV+1a/+H4rCaWypasLB/ac8DEdd6+p7dIm7o3F6P2KZPGkPMqD4s5424EdAdoU+GLA==}
     peerDependencies:
       '@types/react': 19.1.4
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2127,8 +2804,24 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-visually-hidden@1.2.9':
+    resolution: {integrity: sha512-seuZXNZVCz1kLSQMRO/TdNOSahBI3S5nXE4jzO7u7aFRWQlMAnwyrr8vKMkEU115fCLEyzR2YyjnP+aRMxK34w==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@radix-ui/rect@1.1.3':
+    resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
   '@rollup/plugin-babel@5.3.1':
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
@@ -4804,6 +5497,19 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  radix-ui@1.6.5:
+    resolution: {integrity: sha512-HVHPWDoOXBYxxiwvWR45KPcmvrjoa/NTFUbPbGmYoZv7BFYOIpZKiPQZWcpFJTX5z4LeoGenGCUgoafdYHuPWA==}
+    peerDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -4854,6 +5560,16 @@ packages:
 
   react-remove-scroll@2.7.0:
     resolution: {integrity: sha512-sGsQtcjMqdQyijAHytfGEELB8FufGbfXIsvUTe+NLx1GDRJCXtCFLBLUI1eyZCKXXvbEU2C6gai0PZKoIE9Vbg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': 19.1.4
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': 19.1.4
@@ -7219,7 +7935,20 @@ snapshots:
 
   '@radix-ui/number@1.1.1': {}
 
+  '@radix-ui/number@1.1.3': {}
+
   '@radix-ui/primitive@1.1.2': {}
+
+  '@radix-ui/primitive@1.1.7': {}
+
+  '@radix-ui/react-accessible-icon@1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
   '@radix-ui/react-accordion@1.2.10(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -7232,6 +7961,23 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-accordion@1.2.18(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collapsible': 1.1.18(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7252,9 +7998,40 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-alert-dialog@1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-arrow@1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-arrow@1.1.6(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-aspect-ratio@1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7268,6 +8045,20 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-avatar@1.2.4(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.2(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7290,6 +8081,21 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-checkbox@1.3.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-collapsible@1.1.10(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -7300,6 +8106,34 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-collapsible@1.1.18(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-collection@1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7324,7 +8158,32 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
 
+  '@radix-ui/react-compose-refs@1.1.4(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-context-menu@2.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-menu': 2.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-context@1.1.2(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-context@1.2.1(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
@@ -7352,11 +8211,53 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-dialog@1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.4
+
+  '@radix-ui/react-direction@1.1.3(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-dismissable-layer@1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-effect-event': 0.0.4(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
   '@radix-ui/react-dismissable-layer@1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -7386,11 +8287,43 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-dropdown-menu@2.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-menu': 2.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-focus-guards@1.1.2(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.4
+
+  '@radix-ui/react-focus-guards@1.1.5(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-focus-scope@1.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
   '@radix-ui/react-focus-scope@1.1.6(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -7403,12 +8336,59 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-form@0.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-label': 2.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-hover-card@1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popper': 1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.4
+
+  '@radix-ui/react-id@1.1.3(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-label@2.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
   '@radix-ui/react-label@2.1.6(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -7445,6 +8425,108 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-menu@2.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-popper': 1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-menubar@1.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-menu': 2.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-navigation-menu@1.2.20(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-one-time-password-field@0.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-effect-event': 0.0.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.2(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-password-toggle-field@0.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-effect-event': 0.0.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.2(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-popover@1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -7468,6 +8550,30 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-popover@1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-popper': 1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-popper@1.2.6(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -7480,6 +8586,34 @@ snapshots:
       '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/rect': 1.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-popper@1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-arrow': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-rect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/rect': 1.1.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-portal@1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7506,9 +8640,37 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-presence@1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-primitive@2.1.2(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.2(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-primitive@2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-progress@1.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7543,6 +8705,42 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-radio-group@1.4.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-roving-focus@1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.2(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-roving-focus@1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -7554,6 +8752,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-scroll-area@1.2.16(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7589,6 +8804,45 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-select@2.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-popper': 1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-separator@1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-separator@1.1.6(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -7617,9 +8871,36 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-slider@1.4.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-slot@1.2.2(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-slot@1.3.1(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.4
@@ -7639,6 +8920,20 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-switch@1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/react-tabs@1.1.11(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -7649,6 +8944,104 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-roving-focus': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-tabs@1.1.19(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-toast@1.2.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-toggle-group@1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle': 1.1.16(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-toggle@1.1.16(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-toolbar@1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle-group': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
+  '@radix-ui/react-tooltip@1.2.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-popper': 1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7681,10 +9074,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
 
+  '@radix-ui/react-use-callback-ref@1.1.3(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-use-controllable-state@1.2.5(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-use-effect-event': 0.0.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.4
@@ -7696,9 +9104,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
 
+  '@radix-ui/react-use-effect-event@0.0.4(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-use-escape-keydown@1.1.4(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.4
@@ -7710,13 +9132,31 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
 
+  '@radix-ui/react-use-is-hydrated@0.1.2(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.4
 
+  '@radix-ui/react-use-layout-effect@1.1.3(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-use-previous@1.1.3(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
@@ -7729,9 +9169,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
 
+  '@radix-ui/react-use-rect@1.1.3(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.3
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@radix-ui/react-use-size@1.1.3(@types/react@19.1.4)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.4
@@ -7745,7 +9199,18 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
+  '@radix-ui/react-visually-hidden@1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   '@radix-ui/rect@1.1.1': {}
+
+  '@radix-ui/rect@1.1.3': {}
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.29.7)(rollup@2.80.0)':
     dependencies:
@@ -10874,6 +12339,69 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  radix-ui@1.6.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-accessible-icon': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-accordion': 1.2.18(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-alert-dialog': 1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-arrow': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-aspect-ratio': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-avatar': 1.2.4(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-checkbox': 1.3.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collapsible': 1.1.18(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collection': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context': 1.2.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-context-menu': 2.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dropdown-menu': 2.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-form': 0.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-hover-card': 1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-label': 2.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-menu': 2.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-menubar': 1.1.22(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-navigation-menu': 1.2.20(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-one-time-password-field': 0.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-password-toggle-field': 0.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popover': 1.1.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popper': 1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.15(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-progress': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-radio-group': 1.4.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-scroll-area': 1.2.16(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-select': 2.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator': 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slider': 1.4.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-switch': 1.3.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.19(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toast': 1.2.21(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle': 1.1.16(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle-group': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toolbar': 1.1.17(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tooltip': 1.2.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.5(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-effect-event': 0.0.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.4(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.2(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.3(@types/react@19.1.4)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+      '@types/react-dom': 19.1.5(@types/react@19.1.4)
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -10927,6 +12455,17 @@ snapshots:
       '@types/react': 19.1.4
 
   react-remove-scroll@2.7.0(@types/react@19.1.4)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.4)(react@19.1.0)
+      react-style-singleton: 2.2.3(@types/react@19.1.4)(react@19.1.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.1.4)(react@19.1.0)
+      use-sidecar: 1.1.3(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  react-remove-scroll@2.7.2(@types/react@19.1.4)(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-remove-scroll-bar: 2.3.8(@types/react@19.1.4)(react@19.1.0)

--- a/types/themes.ts
+++ b/types/themes.ts
@@ -30,6 +30,8 @@ export const createThemeSchema = z.object({
       .string()
       .regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, "Invalid hex color"),
     gradient: z.string().optional().describe("Optional gradient CSS string for the theme"),
+    ambientGradient: z.string().optional().describe("Optional ambient gradient CSS string for the theme"),
+    cardGradient: z.string().optional().describe("Optional card gradient CSS string for the theme"),
   }),
   type: z.enum(["basic", "light", "dark", "custom"]).default("custom"),
   createdAt: z.string().default(() => new Date().toISOString()),
@@ -63,5 +65,7 @@ export interface Theme {
     muted: string;
     border: string;
     gradient?: string;
+    ambientGradient?: string;
+    cardGradient?: string;
   };
 }

--- a/types/themes.ts
+++ b/types/themes.ts
@@ -29,6 +29,7 @@ export const createThemeSchema = z.object({
     border: z
       .string()
       .regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, "Invalid hex color"),
+    gradient: z.string().optional().describe("Optional gradient CSS string for the theme"),
   }),
   type: z.enum(["basic", "light", "dark", "custom"]).default("custom"),
   createdAt: z.string().default(() => new Date().toISOString()),
@@ -61,5 +62,6 @@ export interface Theme {
     accent: string;
     muted: string;
     border: string;
+    gradient?: string;
   };
 }


### PR DESCRIPTION
This PR prepares the **v1.5.1** release by merging the latest changes from `development` into `staging`.

### What's Included

* Added gradient theme support across the application.
* Introduced card gradient theme variables for consistent UI styling.
* Implemented nested Settings navigation with breadcrumbs and back button support.
* Added itinerary import flow with a custom confirmation dialog.
* Migrated public share routes from `/share` to `/explore`.
* Refactored header navigation into modular components.
* Extended the public share schema to support itinerary budgets.
* Performed internal cleanup and code refactoring.

## Testing

* [x] Verified theme switching and gradient styling.
* [x] Verified Settings navigation and breadcrumbs.
* [x] Verified itinerary import flow.
* [x] Verified `/explore` routing and public sharing.
* [x] Confirmed application builds successfully.

Closes #59.
